### PR TITLE
FAQ: Turborepo Missing Styles Solution

### DIFF
--- a/apps/docs/content/docs/ui/index.mdx
+++ b/apps/docs/content/docs/ui/index.mdx
@@ -91,6 +91,32 @@ npm run dev
         - Built on App Router
         - Use it in an existing Next.js project, without refactoring anything.
     </Accordion>
+    <Accordion id='fix-turborepo-styling' title="How to fix Turborepo stylings not being applied?">
+
+        Turborepo, keeps all installed packages from the `apps` folder in the root directory of your project.
+        This means that when using Tailwind, it will not be able to find the `DocsLayout` from the package `fumadocs-ui`
+        which contains the styling.
+
+        To fix this, edit the `tailwind.config.js` and replace `./node_modules` with `../../node_modules` in the `content` section.
+    
+        Before:
+        ```
+          content: [
+            './node_modules/fumadocs-ui/dist/**/*.js',
+            './components/**/*.{ts,tsx}',
+            ...
+          ],
+        ```
+
+        After:
+        ```
+          content: [
+            '../../node_modules/fumadocs-ui/dist/**/*.js',
+            './components/**/*.{ts,tsx}',
+            ...
+          ],
+        ```
+    </Accordion>
     <Accordion id='fix-supports-color' title="How to fix 'supports-color' error?">
 
         If you got this error:


### PR DESCRIPTION
This Pull Request adds guidance to a common problem a user might experience when using `Turborepo` with `Tailwindcss`. The issue is that by default in the Tailwind Config, will look for the `node_modules` containing `fumadocs/ui` which is needed for the styling with `DocsLayout`, which explains why the root page directing the user to go to `/docs` works with tailwind as expected. The fix is to edit `tailwind.config.js` and instead of `./node_modules`, it is `../../node_modules`.

This will add another accordion element to [Fumadocs FAQ](https://fumadocs.vercel.app/docs/ui#faq).

Thank you for Fumadocs.
> WillKirkmanM