### PR TITLE
adding dark:prose-invert to the docs body to support dark mode

### DIFF
--- a/packages/ui/src/page.tsx
+++ b/packages/ui/src/page.tsx
@@ -106,7 +106,7 @@ export const DocsBody = forwardRef<
   HTMLDivElement,
   HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('prose', className)} {...props} />
+  <div ref={ref} className={cn('prose dark:prose-invert', className)} {...props} />
 ));
 
 DocsBody.displayName = 'DocsBody';


### PR DESCRIPTION
without:
<img width="782" alt="Screenshot 2024-05-31 at 12 40 25 AM" src="https://github.com/fuma-nama/fumadocs/assets/123222405/281e62b6-0f1b-4d42-882b-ee96de855b4e">

with:
<img width="604" alt="Screenshot 2024-05-31 at 12 40 42 AM" src="https://github.com/fuma-nama/fumadocs/assets/123222405/53ed3802-b40c-480f-87db-7d83807dd7ce">
