### PR TITLE
Fix multi-line frontmatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,19 +34,19 @@
   },
   "packageManager": "pnpm@9.2.0",
   "pnpm": {
-    "overrides": {
-      "@opentelemetry/api": "^1.4.1",
-      "remark-rehype": "^11.0.0",
-      "@types/mdast": "^4.0.3",
-      "remark-parse": "^11.0.0",
-      "unified": "^11.0.4",
-      "mdx-bundler": "^10.0.1"
-    },
     "peerDependencyRules": {
       "ignoreMissing": [
         "esbuild",
         "next"
       ]
+    },
+    "overrides": {
+      "@opentelemetry/api": "^1.4.1",
+      "@types/mdast": "^4.0.3",
+      "mdx-bundler": "^10.0.1",
+      "remark-parse": "^11.0.0",
+      "remark-rehype": "^11.0.0",
+      "unified": "^11.0.4"
     }
   }
 }

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -123,7 +123,7 @@ function render(
       [
         '---',
         title && `title: ${title}`,
-        description && `description: ${description}`,
+        description && 'description: |\n  ' + description.split('\n').join('\n  ') + '\n',
         '---',
       ]
         .filter(Boolean)

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -123,7 +123,8 @@ function render(
       [
         '---',
         title && `title: ${title}`,
-        description && 'description: |\n  ' + description.split('\n').join('\n  ') + '\n',
+        description &&
+          'description: |\n  ' + description.split('\n').join('\n  ') + '\n',
         '---',
       ]
         .filter(Boolean)

--- a/packages/openapi/test/out/museum/events.mdx
+++ b/packages/openapi/test/out/museum/events.mdx
@@ -1,6 +1,8 @@
 ---
 title: Events
-description: Special events hosted by the Museum
+description: |
+  Special events hosted by the Museum
+
 ---
 
 import { Root, API, APIInfo, APIExample, Property } from 'fumadocs-ui/components/api'

--- a/packages/openapi/test/out/museum/operations.mdx
+++ b/packages/openapi/test/out/museum/operations.mdx
@@ -1,6 +1,8 @@
 ---
 title: Operations
-description: Operational information about the museum.
+description: |
+  Operational information about the museum.
+
 ---
 
 import { Root, API, APIInfo, APIExample, Property } from 'fumadocs-ui/components/api'

--- a/packages/openapi/test/out/museum/tickets.mdx
+++ b/packages/openapi/test/out/museum/tickets.mdx
@@ -1,6 +1,8 @@
 ---
 title: Tickets
-description: Museum tickets for general entrance or special events.
+description: |
+  Museum tickets for general entrance or special events.
+
 ---
 
 import { Root, API, APIInfo, APIExample, Property } from 'fumadocs-ui/components/api'


### PR DESCRIPTION
If `description` is multiple lines, this script would generate syntactically invalid frontmatter.