### PR TITLE
Docs: Fix typo enabled in search.mdx

### DIFF
--- a/apps/docs/content/docs/ui/search.mdx
+++ b/apps/docs/content/docs/ui/search.mdx
@@ -68,7 +68,7 @@ To opt-out of document search, disable it from root provider.
 ```mdx
 <RootProvider
   search={{
-    enable: false,
+    enabled: false,
   }}
 >
   {children}


### PR DESCRIPTION
I find a typo problem after copy and paste from documentation

Missing the 'd' word on search page at [UI docs](https://fumadocs.vercel.app/docs/ui/search#disable-search)

![image](https://github.com/fuma-nama/fumadocs/assets/6184866/78f8bef6-9c03-465b-84ba-6448aaae2da2)
