### PR TITLE
Fix search hotkey icons order

### DIFF
--- a/.changeset/late-crabs-hear.md
+++ b/.changeset/late-crabs-hear.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-ui': patch
+---
+
+Fixed the order of displayed hotkey icons in search toggle

--- a/apps/docs/content/docs/ui/search.mdx
+++ b/apps/docs/content/docs/ui/search.mdx
@@ -6,7 +6,7 @@ icon: Search
 
 Fumadocs UI provides a good-looking search dialog out-of-the-box.
 
-Open with <kbd>K</kbd> <kbd>⌘</kbd> or <kbd>K</kbd> <kbd>Ctrl</kbd>.
+Open with <kbd>⌘</kbd> <kbd>K</kbd> or <kbd>Ctrl</kbd> <kbd>K</kbd>.
 
 > [Configure Document Search](/docs/headless/search).
 

--- a/packages/ui/src/contexts/search.tsx
+++ b/packages/ui/src/contexts/search.tsx
@@ -26,7 +26,7 @@ export interface SearchProviderProps {
   /**
    * Hotkeys for triggering search dialog
    *
-   * @defaultValue K + Meta/Ctrl
+   * @defaultValue Meta/Ctrl + K
    */
   hotKey?: HotKey[];
 
@@ -68,12 +68,12 @@ export function SearchProvider({
   options,
   hotKey = [
     {
-      key: 'k',
-      display: 'K',
-    },
-    {
       key: (e) => e.metaKey || e.ctrlKey,
       display: '⌘',
+    },
+    {
+      key: 'k',
+      display: 'K',
     },
   ],
   links,


### PR DESCRIPTION
Fixing this issue: https://github.com/fuma-nama/fumadocs/issues/491

Screenshots:
<img width="251" alt="image" src="https://github.com/fuma-nama/fumadocs/assets/6877691/dfaf8362-a42a-48e0-a1f4-a76f29c70db2">

<img width="529" alt="image" src="https://github.com/fuma-nama/fumadocs/assets/6877691/9ef7750d-a70c-4c60-9104-8203a9cabea7">
