### PR TITLE
Add configurable delayMs Parameter for Debounced Search Performance

### DIFF
--- a/packages/core/src/search/client.ts
+++ b/packages/core/src/search/client.ts
@@ -35,14 +35,16 @@ async function fetchDocs(
  * @param locale - Filter with locale
  * @param tag - Filter with specific tag
  * @param api - The Search API URL
+ * @param delayMs - The debounced delay for performing a search.
  */
 export function useDocsSearch(
   locale?: string,
   tag?: string,
   api = '/api/search',
+  delayMs = 100
 ): UseDocsSearch {
   const [search, setSearch] = useState('');
-  const debouncedValue = useDebounce(search, 100);
+  const debouncedValue = useDebounce(search, delayMs);
 
   const query: UseDocsSearch['query'] = useSWR(
     [api, debouncedValue, locale, tag],

--- a/packages/ui/src/components/dialog/search-default.tsx
+++ b/packages/ui/src/components/dialog/search-default.tsx
@@ -16,16 +16,22 @@ export interface DefaultSearchDialogProps extends SharedProps {
    */
   api?: string;
 
+  /**
+   * The debounced delay for performing a search.
+   */
+  delayMs?: number;
+
   footer?: ReactNode;
 }
 
 export default function DefaultSearchDialog({
   tag,
   api,
+  delayMs,
   ...props
 }: DefaultSearchDialogProps): React.ReactElement {
   const { locale } = useI18n();
-  const { search, setSearch, query } = useDocsSearch(locale, tag, api);
+  const { search, setSearch, query } = useDocsSearch(locale, tag, api, delayMs);
 
   return (
     <SearchDialog


### PR DESCRIPTION
Hello there! How are you doing?

Context:
I was working on a custom search implementation using the default implementation, which performs an API call for each search. To reduce the number of requests to the server, I wanted to increase the delayMs to a higher value. However, the current library does not provide a way to pass this parameter in the default implementation.

This PR aims to address that by allowing delayMs to be configurable.