### PR TITLE
Adding secondary custom links

### DIFF
--- a/.changeset/soft-masks-help.md
+++ b/.changeset/soft-masks-help.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-ui": patch
+---
+
+Adding secondary custom links

--- a/packages/ui/src/components/layout/link-item.tsx
+++ b/packages/ui/src/components/layout/link-item.tsx
@@ -52,14 +52,6 @@ export function LinkItem({
     return <></>;
   }
 
-  if (item.type === 'secondary_custom') {
-    const itemSecondaryOn = item.on ?? 'all';
-    if (itemSecondaryOn === 'all' || itemSecondaryOn === on)
-      return item.children;
-    // eslint-disable-next-line react/jsx-no-useless-fragment -- Render nothing
-    return <></>;
-  }
-
   if (item.type === 'menu' && on === 'nav') {
     return (
       <Popover>

--- a/packages/ui/src/components/layout/link-item.tsx
+++ b/packages/ui/src/components/layout/link-item.tsx
@@ -52,6 +52,14 @@ export function LinkItem({
     return <></>;
   }
 
+  if (item.type === 'secondary_custom') {
+    const itemSecondaryOn = item.on ?? 'all';
+    if (itemSecondaryOn === 'all' || itemSecondaryOn === on)
+      return item.children;
+    // eslint-disable-next-line react/jsx-no-useless-fragment -- Render nothing
+    return <></>;
+  }
+
   if (item.type === 'menu' && on === 'nav') {
     return (
       <Popover>

--- a/packages/ui/src/layout.client.tsx
+++ b/packages/ui/src/layout.client.tsx
@@ -32,7 +32,8 @@ export function Nav({
         {items
           .filter(
             (item) =>
-              item.type !== 'secondary' && !(item.type === 'custom' && item.secondary),
+              item.type !== 'secondary' &&
+              !(item.type === 'custom' && item.secondary),
           )
           .map((item, i) => (
             <LinkItem
@@ -53,7 +54,8 @@ export function Nav({
           {items
             .filter(
               (item) =>
-                item.type === 'secondary' || (item.type === 'custom' && item.secondary),
+                item.type === 'secondary' ||
+                (item.type === 'custom' && item.secondary),
             )
             .map((item, i) => (
               <LinkItem key={i} item={item} className="max-lg:hidden" />

--- a/packages/ui/src/layout.client.tsx
+++ b/packages/ui/src/layout.client.tsx
@@ -32,7 +32,7 @@ export function Nav({
         {items
           .filter(
             (item) =>
-              item.type !== 'secondary' && item.type !== 'secondary_custom',
+              item.type !== 'secondary' && !(item.type === 'custom' && item.secondary),
           )
           .map((item, i) => (
             <LinkItem
@@ -53,7 +53,7 @@ export function Nav({
           {items
             .filter(
               (item) =>
-                item.type === 'secondary' || item.type === 'secondary_custom',
+                item.type === 'secondary' || (item.type === 'custom' && item.secondary),
             )
             .map((item, i) => (
               <LinkItem key={i} item={item} className="max-lg:hidden" />

--- a/packages/ui/src/layout.client.tsx
+++ b/packages/ui/src/layout.client.tsx
@@ -30,7 +30,10 @@ export function Nav({
         <Title title={title} url={url} />
         {children}
         {items
-          .filter((item) => item.type !== 'secondary')
+          .filter(
+            (item) =>
+              item.type !== 'secondary' && item.type !== 'secondary_custom',
+          )
           .map((item, i) => (
             <LinkItem
               key={i}
@@ -48,7 +51,10 @@ export function Nav({
 
           <ThemeToggle className="max-lg:hidden" />
           {items
-            .filter((item) => item.type === 'secondary')
+            .filter(
+              (item) =>
+                item.type === 'secondary' || item.type === 'secondary_custom',
+            )
             .map((item, i) => (
               <LinkItem key={i} item={item} className="max-lg:hidden" />
             ))}

--- a/packages/ui/src/layout.tsx
+++ b/packages/ui/src/layout.tsx
@@ -65,16 +65,7 @@ export type LinkItemType =
        * @defaultValue 'all'
        */
       on?: 'menu' | 'nav' | 'all';
-      children: ReactElement;
-    }
-  | {
-      type: 'secondary_custom';
-      /**
-       * Restrict where the item is displayed for secondary links
-       *
-       * @defaultValue 'all'
-       */
-      on?: 'menu' | 'nav' | 'all';
+      secondary?: boolean;
       children: ReactElement;
     };
 

--- a/packages/ui/src/layout.tsx
+++ b/packages/ui/src/layout.tsx
@@ -66,6 +66,16 @@ export type LinkItemType =
        */
       on?: 'menu' | 'nav' | 'all';
       children: ReactElement;
+    }
+  | {
+      type: 'secondary_custom';
+      /**
+       * Restrict where the item is displayed for secondary links
+       *
+       * @defaultValue 'all'
+       */
+      on?: 'menu' | 'nav' | 'all';
+      children: ReactElement;
     };
 
 interface NavOptions extends SharedNavProps {


### PR DESCRIPTION
Hello there!
I hope you're doing well.

I’d love to propose adding support for secondary custom links, allowing us to place additional content next to the existing GitHub URL for example. Instead of a basic link with a secondary type, I would like to include a customizable component right next to the other link.

I've implemented a solution to achieve this without impacting the current custom type. However, I would appreciate your feedback on whether this is the best approach or if we should consider enhancing the `custom` type property to include secondary on the `on` property.

Thank you for this amazing project! It has been incredibly beneficial for our work.