### PR TITLE
Add support for anyOf

### DIFF
--- a/packages/openapi/src/render/schema.ts
+++ b/packages/openapi/src/render/schema.ts
@@ -83,6 +83,21 @@ export function schemaElement(
     });
 
     return child.join('\n\n');
+  } else if (
+    schema.anyOf?.reduce(
+      (acc, s) => acc || Boolean(resolveObjectType(noRef(s))),
+      false,
+    )
+  ) {
+    child.push(
+      ...schema.anyOf.map((s, idx) =>
+        schemaElement(`${name} (option ${(idx + 1).toString()})`, noRef(s), {
+          ...ctx,
+          required: false,
+          parseObject: false,
+        }),
+      ),
+    );
   }
 
   child.push(p(schema.description));
@@ -127,7 +142,7 @@ export function schemaElement(
 function resolveObjectType(
   schema: OpenAPI.SchemaObject,
 ): OpenAPI.SchemaObject | undefined {
-  if (isObject(schema)) return schema;
+  if (isObject(schema) || schema.anyOf) return schema;
 
   if (schema.type === 'array') {
     return resolveObjectType(noRef(schema.items));


### PR DESCRIPTION
Fixes #567

Renders `anyOf` options as children, similar to object rendering, with a naming convention:

<img width="460" alt="Screenshot 2024-07-04 at 6 08 42 PM" src="https://github.com/fuma-nama/fumadocs/assets/565363/127e6af9-7b03-4b67-99b3-fe3e973f0437">

Definitely open to alternatives/suggestions on how to render it!