### PR TITLE
Remove `Bearer` from `accessToken` in Remote MDX Docs

### DIFF
--- a/apps/docs/content/docs/headless/remote/github.mdx
+++ b/apps/docs/content/docs/headless/remote/github.mdx
@@ -41,7 +41,7 @@ export const getDocs = cache(async () => {
         repo: 'fumadocs',
         directory: 'examples/remote-mdx/content',
         treeSha: 'main',
-        accessToken: 'Bearer <access token>',
+        accessToken: '<access token>',
       },
     }),
     rootDir: 'docs',

--- a/apps/docs/content/docs/headless/remote/github.mdx
+++ b/apps/docs/content/docs/headless/remote/github.mdx
@@ -41,7 +41,7 @@ export const getDocs = cache(async () => {
         repo: 'fumadocs',
         directory: 'examples/remote-mdx/content',
         treeSha: 'main',
-        accessToken: '<access token>',
+        accessToken: process.env.GITHUB_ACCESS_TOKEN!,
       },
     }),
     rootDir: 'docs',


### PR DESCRIPTION
There's an issue in the Setup of Remote MDX documentation here: https://fumadocs.vercel.app/docs/headless/remote/github#setup

<img width="906" alt="Screenshot 2024-07-09 at 20 54 20" src="https://github.com/fuma-nama/fumadocs/assets/41383181/d91157d8-733b-4768-b266-1416ce0d63c5">

The docs mention that the `accessToken` key must include the whole `Authorization` header content, including the `Bearer` prefix.

However, that is not necessary and causes builds to fail because FumaDocs internally adds the `Bearer` prefix in the `fetchTree` utility here:

https://github.com/fuma-nama/fumadocs/blob/16d06df180af5822fc59003488600b41195d083d/packages/mdx-remote/src/github/api/fetch-tree.ts#L56

The `Authorization` header content ends up being `Bearer Bearer <access-token>` and the builds fail.