### PR TITLE
Fix bug breaking Tailwind CSS IntelliSense VSCode Extension

### DIFF
--- a/.changeset/shiny-maps-flash.md
+++ b/.changeset/shiny-maps-flash.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-ui': patch
+---
+
+Fix bug breaking Tailwind CSS IntelliSense VSCode Extension

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,8 +17,8 @@
     "./image-zoom.css": "./dist/image-zoom.css",
     "./tailwind-plugin": {
       "import": "./dist/tailwind-plugin.js",
-      "default": "./dist/tailwind-plugin.js",
-      "types": "./dist/tailwind-plugin.d.ts"
+      "types": "./dist/tailwind-plugin.d.ts",
+      "default": "./dist/tailwind-plugin.js"
     },
     "./components/*": {
       "import": "./dist/components/*.js",


### PR DESCRIPTION
Usage of the tailwind plugin (`fumadocs-ui/tailwind-plugin`) breaks the Tailwind CSS IntelliSense VSCode Extension. When included (i.e. in the default template), the following error message occurs:
```
[Error - 3:54:20 PM] Tailwind CSS: Default condition should be last one
Error: Default condition should be last one
    at WU (/Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:11675)
    at /Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:8936
    at /Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:13933
    at Zy.eval [as callAsync] (eval at create (/Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:5:78), <anonymous>:22:1)
    at e.doResolve (/Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:340)
    at /Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:7779
    at /Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:3337
    at /Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:2390
    at H (/Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:3259)
    at /Users/adam/.vscode/extensions/bradlc.vscode-tailwindcss-0.12.5/dist/tailwindServer.js:134:2847
```

After removing the `fumadocs-ui/tailwind-plugin` import from the `tailwind.config.js` file, the error no longer occurs. This validates that the error is coming from the plugin.

It appears moving the `defaults` export to the end resolves the issue (https://github.com/tailwindlabs/tailwindcss-intellisense/issues/778#issuecomment-1777981969). Please let me know if any other changes are needed, thank you!