### PR TITLE
small accessibility issue in `CopyRouteButton`

### DIFF
--- a/packages/openapi/src/ui/client.tsx
+++ b/packages/openapi/src/ui/client.tsx
@@ -19,7 +19,7 @@ export function Root({
   return (
     <div
       className={cn(
-        'flex flex-col gap-24 text-sm text-fd-muted-foreground',
+        'text-fd-muted-foreground flex flex-col gap-24 text-sm',
         className,
       )}
       {...props}
@@ -52,6 +52,7 @@ export function CopyRouteButton({
         }),
       )}
       onClick={onCopy}
+      aria-label="Copy route path"
       {...props}
     >
       {checked ? <Check className="size-3" /> : <Copy className="size-3" />}


### PR DESCRIPTION
The copy route button doesn't have discernible text