### PR TITLE
Fixed typo for i18n across documents

### DIFF
--- a/apps/docs/content/blog/v12.mdx
+++ b/apps/docs/content/blog/v12.mdx
@@ -53,7 +53,7 @@ export const utils = loader({
 });
 ```
 
-### Improved I18n Support
+### Improved i18n Support
 
 The language switch is now added to Docs Layout.
 

--- a/apps/docs/content/blog/v13.mdx
+++ b/apps/docs/content/blog/v13.mdx
@@ -133,10 +133,10 @@ Now users can use the TOC Popover to switch between headings, it is no longer a 
 
 You may copy the [last implementation of `RollButton`](https://github.com/fuma-nama/fumadocs/blob/fumadocs-ui%4012.5.6/packages/ui/src/components/roll-button.tsx).
 
-### Better I18n
+### Better i18n
 
-Now the `I18nProvider` component requires the `locale` prop instead of parsing it from pathname.
-This fixed some bugs with the I18n middleware.
+Now the `i18nProvider` component requires the `locale` prop instead of parsing it from pathname.
+This fixed some bugs with the i18n middleware.
 
 We also changed the usage of `translations` to reduce extra translations loaded on client side.
 You have to pass the active translations directly.

--- a/apps/docs/content/blog/v13.mdx
+++ b/apps/docs/content/blog/v13.mdx
@@ -135,8 +135,8 @@ You may copy the [last implementation of `RollButton`](https://github.com/fuma-n
 
 ### Better i18n
 
-Now the `i18nProvider` component requires the `locale` prop instead of parsing it from pathname.
-This fixed some bugs with the i18n middleware.
+Now the `I18nProvider` component requires the `locale` prop instead of parsing it from pathname.
+This fixed some bugs with the I18n middleware.
 
 We also changed the usage of `translations` to reduce extra translations loaded on client side.
 You have to pass the active translations directly.

--- a/apps/docs/content/docs/headless/internationalization.mdx
+++ b/apps/docs/content/docs/headless/internationalization.mdx
@@ -4,7 +4,7 @@ description: Support multiple languages in your documentation
 icon: Globe
 ---
 
-> Read the [Next.js Docs](https://nextjs.org/docs/app/building-your-application/routing/internationalization) to learn more about implementing I18n in Next.js.
+> Read the [Next.js Docs](https://nextjs.org/docs/app/building-your-application/routing/internationalization) to learn more about implementing i18n in Next.js.
 
 ## Setup
 
@@ -69,7 +69,7 @@ export default function Layout({
 
 <UIOnly>
 
-A `I18nProvider` is needed for localization. Wrap the root provider inside your I18n provider.
+A `i18nProvider` is needed for localization. Wrap the root provider inside your i18n provider.
 
 ```tsx
 import { RootProvider } from 'fumadocs-ui/provider';
@@ -112,7 +112,7 @@ export default function RootLayout({
 
 ### Search
 
-Configure i18n on your search solution. For Flexsearch, see [Setup I18n](/docs/headless/search/flexsearch#internationalization).
+Configure i18n on your search solution. For Flexsearch, see [Setup i18n](/docs/headless/search/flexsearch#internationalization).
 
 ### Get Pages
 
@@ -152,7 +152,7 @@ export async function generateStaticParams() {
 
 ### Middleware Options
 
-You can also customise the I18n middleware.
+You can also customise the i18n middleware.
 
 #### Hide Locale Prefix
 

--- a/apps/docs/content/docs/headless/internationalization.mdx
+++ b/apps/docs/content/docs/headless/internationalization.mdx
@@ -69,7 +69,7 @@ export default function Layout({
 
 <UIOnly>
 
-A `i18nProvider` is needed for localization. Wrap the root provider inside your i18n provider.
+A `I18nProvider` is needed for localization. Wrap the root provider inside your I18n provider.
 
 ```tsx
 import { RootProvider } from 'fumadocs-ui/provider';

--- a/apps/docs/content/docs/ui/comparisons.mdx
+++ b/apps/docs/content/docs/ui/comparisons.mdx
@@ -44,7 +44,7 @@ adding it to an existing codebase or implementing advanced routing.
 | Syntax Highlighting | Yes          | Yes               |
 | Table of Contents   | Yes          | Yes               |
 | Full-text Search    | Yes          | Yes               |
-| I18n                | Yes          | Yes               |
+| i18n                | Yes          | Yes               |
 | Last Git Edit Time  | Yes          | Yes               |
 | Page Icons          | Yes          | No                |
 | RSC                 | Yes          | Pages Router Only |

--- a/apps/docs/content/docs/ui/index.mdx
+++ b/apps/docs/content/docs/ui/index.mdx
@@ -168,8 +168,8 @@ If you find anything confusing, please give your feedback on [Github Discussion]
   />
   <Card
     href="/docs/ui/internationalization"
-    title="Learn I18n"
-    description="Learn how to implement I18n"
+    title="Learn i18n"
+    description="Learn how to implement i18n"
   />
   <Card
     href="/docs/ui/theme"

--- a/examples/i18n/content/docs/index.cn.mdx
+++ b/examples/i18n/content/docs/index.cn.mdx
@@ -5,4 +5,4 @@ description: 您的第一個文檔
 
 ## Hi 中文
 
-Fumadocs 對 I18n 有良好的支持
+Fumadocs 對 i18n 有良好的支持

--- a/examples/remote-mdx/content/docs/bry.mdx
+++ b/examples/remote-mdx/content/docs/bry.mdx
@@ -45,7 +45,7 @@ adding it to an existing codebase or implementing advanced routing.
 | Syntax Highlighting | Yes          | Yes               |
 | Table of Contents   | Yes          | Yes               |
 | Full-text Search    | Yes          | Yes               |
-| I18n                | Yes          | Yes               |
+| i18n                | Yes          | Yes               |
 | Last Git Edit Time  | Yes          | Yes               |
 | Page Icons          | Yes          | No                |
 | RSC                 | Yes          | Pages Router Only |


### PR DESCRIPTION
Replaced `I18n` with `i18n` across the documents. I made sure to keep the functions named as it is.