### PR TITLE
fix: DocsCategory should support dir index page

### DIFF
--- a/packages/ui/src/page.tsx
+++ b/packages/ui/src/page.tsx
@@ -224,8 +224,8 @@ export function DocsCategory({
     (item) =>
       (item.file.dirname === page.file.dirname &&
         item.file.name !== page.file.name) ||
-      (item.file.name === "index" &&
-        item.file.dirname.split("/").slice(0, -1).join("/") ===
+      (item.file.name === 'index' &&
+        item.file.dirname.split('/').slice(0, -1).join('/') ===
           page.file.dirname),
   );
 

--- a/packages/ui/src/page.tsx
+++ b/packages/ui/src/page.tsx
@@ -222,8 +222,11 @@ export function DocsCategory({
 }): React.ReactElement {
   const filtered = pages.filter(
     (item) =>
-      item.file.dirname === page.file.dirname &&
-      item.file.name !== page.file.name,
+      (item.file.dirname === page.file.dirname &&
+        item.file.name !== page.file.name) ||
+      (item.file.name === "index" &&
+        item.file.dirname.split("/").slice(0, -1).join("/") ===
+          page.file.dirname),
   );
 
   return (


### PR DESCRIPTION
If the page is an index page under the folder of the next level, it should be counted.