### PR TITLE
fix: openapi file upload feature

### DIFF
--- a/packages/openapi/src/ui/api/fetcher.ts
+++ b/packages/openapi/src/ui/api/fetcher.ts
@@ -40,7 +40,9 @@ export function createBodyFromValue(
       }
     }
 
-    formData.set(key, JSON.stringify(prop));
+    if (prop && !(prop instanceof File)) {
+      formData.set(key, JSON.stringify(prop));
+    }
   }
 
   return formData;

--- a/packages/openapi/src/ui/playground.tsx
+++ b/packages/openapi/src/ui/playground.tsx
@@ -86,9 +86,8 @@ export function APIPlayground({
       `${baseUrl ?? window.location.origin}${createUrlFromInput(route, input.path, input.query)}`,
     );
 
-    const headers = new Headers({
-      'Content-Type': 'application/json',
-    });
+    const headers = new Headers();
+    if (bodyType !== 'form-data') headers.append('Content-Type', 'application/json');
 
     if (input.authorization) {
       headers.append('Authorization', input.authorization);


### PR DESCRIPTION
## Problem
- OpenAPI APIPlayground file upload is not working.

### How to reproduce
- Upload file and send in fumadocs `Buy museum tickets` example.
- Payload 'image' field has empty object.
![image](https://github.com/user-attachments/assets/adf4d537-6b91-4722-be44-57f0eebe4b63)

### Changes
- In the `createBodyFromValue` function, I found it resets FormData File field to empty {}. I add condition to set key if it's not File instance.
- For form-data, I changed it to not specify `Content-Type`. Fetch will automatically set it to `multipart/form-data`.
