### PR TITLE
fix: search component in fumadocs-ui package

### DIFF
--- a/packages/ui/src/components/dialog/search.tsx
+++ b/packages/ui/src/components/dialog/search.tsx
@@ -48,6 +48,7 @@ interface SearchContentProps {
   items: SortedResult[];
 
   hideResults?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function SearchDialog({
@@ -74,6 +75,7 @@ export function SearchDialog({
         {...props}
         items={props.results === 'empty' ? defaultItems : props.results}
         hideResults={props.results === 'empty' && defaultItems.length === 0}
+        onOpenChange={onOpenChange}
       />
       {footer ? (
         <div className="mt-auto flex flex-col border-t p-3">{footer}</div>
@@ -94,6 +96,7 @@ function Search({
   items,
   isLoading,
   hideResults = false,
+  onOpenChange = () => {}
 }: SearchContentProps): ReactElement {
   const { text } = useI18n();
   const router = useRouter();
@@ -103,6 +106,7 @@ function Search({
   const onOpen = (url: string): void => {
     router.push(url);
     setOpenSearch(false);
+    onOpenChange(false);
 
     if (location.pathname === url.split('#')[0]) {
       sidebar.setOpen(false);
@@ -116,6 +120,7 @@ function Search({
         onValueChange={onSearchChange}
         onClose={() => {
           setOpenSearch(false);
+          onOpenChange(false);
         }}
         placeholder={text.search}
       >


### PR DESCRIPTION
## Problem

> onOpenChange inside search dialog component is not working in some situlations

I needed to customize the use of the button that opens the Search Dialog to place it where I wanted it to be

While looking for a way to do this, I found your docs ([link](https://fumadocs.vercel.app/docs/ui/search#built-in-ui))

```typescript
export default function CustomSearch() {
  const [isOpen, setIsOpen] = useState(false)
  // ...

  return (
    <>
       // ...
       <SearchDialog
        open={isOpen}
        onOpenChange={setIsOpen}
        // ...
      />
    </>
  )
}
```

However, clicking the ESC button or clicking a result in the Dialog list did not close the Search Dialog

https://github.com/user-attachments/assets/b3820143-2bfa-4461-8853-48b56c3e7ae7

## Solution & Suggest

I solved the problem in the same way as this PR

I propose to apply this fix

## Changes

- Add `onOpenChange` props in search component
- Use `onOpenChange` method when need to close the search dialog