### PR TITLE
Support multiple tags in OpenAPI `groupBy: tag` file generation

### DIFF
--- a/.changeset/quick-bears-refuse.md
+++ b/.changeset/quick-bears-refuse.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-openapi": patch
+---
+
+Support multiple tags in OpenAPI `groupBy: tag` file generation

--- a/packages/openapi/src/generate-file.ts
+++ b/packages/openapi/src/generate-file.ts
@@ -91,7 +91,7 @@ export async function generateFiles(options: Config): Promise<void> {
 
         await Promise.all(
           results.map(async (result) => {
-            let outPath;
+            let outPaths = new Array<string>();
             if (!result.method.operationId) return;
             const id =
               result.method.operationId.split('.').at(-1) ??
@@ -102,18 +102,16 @@ export async function generateFiles(options: Config): Promise<void> {
               result.method.tags &&
               result.method.tags.length > 0
             ) {
-              if (result.method.tags.length > 1)
-                console.warn(
-                  `${result.route.path} has more than 1 tag, which isn't allowed under 'groupBy: tag'. Only the first tag will be considered.`,
-                );
-
-              outPath = join(
-                outputDir,
-                getFilename(result.method.tags[0]),
-                `${getFilename(id)}.mdx`,
-              );
+              for (const tag of result.method.tags) {
+                outPaths.push(join(
+                  outputDir,
+                  getFilename(tag),
+                  `${getFilename(id)}.mdx`,
+                ));
+              }
             } else if (groupBy === 'route') {
-              outPath = join(
+
+              let outPath = join(
                 outputDir,
                 result.route.summary
                   ? getFilename(result.route.summary)
@@ -133,12 +131,16 @@ export async function generateFiles(options: Config): Promise<void> {
                 );
                 console.log(`Generated Meta: ${metaFile}`);
               }
+
+              outPaths.push(outPath)
             } else {
-              outPath = join(outputDir, `${getFilename(id)}.mdx`);
+              outPaths.push(join(outputDir, `${getFilename(id)}.mdx`))
             }
 
-            await write(outPath, result.content);
-            console.log(`Generated: ${outPath}`);
+            for (const outPath of outPaths) {
+              await write(outPath, result.content);
+              console.log(`Generated: ${outPath}`);
+            }
           }),
         );
         return;

--- a/packages/openapi/test/fixtures/products.yaml
+++ b/packages/openapi/test/fixtures/products.yaml
@@ -1,0 +1,72 @@
+openapi: 3.0.3
+info:
+  title: Inventory/Product API
+  description: A minimal test fixture for Inventory and Product operations.
+  version: 1.0.0
+
+tags:
+  - name: Products
+    description: Operations related to products.
+  - name: Inventory
+    description: Operations related to inventory.
+
+paths:
+  /products/{productId}:
+    get:
+      summary: Get product details
+      description: Retrieve details of a product by its ID.
+      operationId: getProductDetails
+      tags:
+        - Products
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          description: ID of the product to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response with product details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Product ID
+                  price:
+                    type: number
+                    description: Price of the product
+        '404':
+          description: Product not found
+
+  /inventory/{productId}:
+    get:
+      summary: Get product inventory
+      description: Retrieve inventory details for a specific product.
+      operationId: getInventoryForProduct
+      tags:
+        - Inventory
+        - Products
+      parameters:
+        - name: productId
+          in: path
+          required: true
+          description: ID of the product to retrieve inventory information
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response with inventory details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  productId:
+                    type: string
+                    description: Product ID
+        '404':
+          description: Product not found

--- a/packages/openapi/test/index.test.ts
+++ b/packages/openapi/test/index.test.ts
@@ -87,7 +87,7 @@ describe('Generate documents', () => {
   test('Generate Files - groupBy tag per operation', async () => {
     await generateFiles({
       input: ['./fixtures/products.yaml'],
-      output: './out/products',
+      output: './out',
       per: 'operation',
       groupBy: 'tag',
       cwd,
@@ -98,21 +98,21 @@ describe('Generate documents', () => {
     expect(fs.writeFile).toBeCalledTimes(3);
 
     expect(fs.writeFile).toBeCalledWith(
-      join(cwd, './out/products/products/get-product-details.mdx'),
+      join(cwd, './out/products/get-product-details.mdx'),
       expect.anything(),
     );
 
     expect(fs.writeFile).toBeCalledWith(
-      join(cwd, './out/products/products/get-inventory-for-product.mdx'),
+      join(cwd, './out/products/get-inventory-for-product.mdx'),
       expect.anything(),
     );
 
     expect(fs.writeFile).toBeCalledWith(
-      join(cwd, './out/products/inventory/get-inventory-for-product.mdx'),
+      join(cwd, './out/inventory/get-inventory-for-product.mdx'),
       expect.anything(),
     );
 
-    expect(fs.mkdir).toBeCalledWith(join(cwd, './out/products/inventory'), expect.anything());
-    expect(fs.mkdir).toBeCalledWith(join(cwd, './out/products/products'), expect.anything());
+    expect(fs.mkdir).toBeCalledWith(join(cwd, './out/inventory'), expect.anything());
+    expect(fs.mkdir).toBeCalledWith(join(cwd, './out/products'), expect.anything());
   });
 });

--- a/packages/openapi/test/index.test.ts
+++ b/packages/openapi/test/index.test.ts
@@ -49,21 +49,21 @@ describe('Generate documents', () => {
     }
   });
 
-  test('Generate Files', async () => {
-    vi.mock('node:fs/promises', async (importOriginal) => {
-      return {
-        ...(await importOriginal<typeof import('node:fs/promises')>()),
-        mkdir: vi.fn().mockImplementation(() => {
-          // do nothing
-        }),
-        writeFile: vi.fn().mockImplementation(() => {
-          // do nothing
-        }),
-      };
-    });
+  vi.mock('node:fs/promises', async (importOriginal) => {
+    return {
+      ...(await importOriginal<typeof import('node:fs/promises')>()),
+      mkdir: vi.fn().mockImplementation(() => {
+        // do nothing
+      }),
+      writeFile: vi.fn().mockImplementation(() => {
+        // do nothing
+      }),
+    };
+  });
 
+  test('Generate Files', async () => {
     await generateFiles({
-      input: ['./fixtures/*.yaml'],
+      input: ['./fixtures/museum.yaml', './fixtures/petstore.yaml'],
       output: './out',
       per: 'file',
       cwd,
@@ -82,5 +82,37 @@ describe('Generate documents', () => {
     );
 
     expect(fs.mkdir).toBeCalledWith(join(cwd, './out'), expect.anything());
+  });
+
+  test('Generate Files - groupBy tag per operation', async () => {
+    await generateFiles({
+      input: ['./fixtures/products.yaml'],
+      output: './out/products',
+      per: 'operation',
+      groupBy: 'tag',
+      cwd,
+    });
+
+    const fs = await import('node:fs/promises');
+
+    expect(fs.writeFile).toBeCalledTimes(3);
+
+    expect(fs.writeFile).toBeCalledWith(
+      join(cwd, './out/products/products/get-product-details.mdx'),
+      expect.anything(),
+    );
+
+    expect(fs.writeFile).toBeCalledWith(
+      join(cwd, './out/products/products/get-inventory-for-product.mdx'),
+      expect.anything(),
+    );
+
+    expect(fs.writeFile).toBeCalledWith(
+      join(cwd, './out/products/inventory/get-inventory-for-product.mdx'),
+      expect.anything(),
+    );
+
+    expect(fs.mkdir).toBeCalledWith(join(cwd, './out/products/inventory'), expect.anything());
+    expect(fs.mkdir).toBeCalledWith(join(cwd, './out/products/products'), expect.anything());
   });
 });


### PR DESCRIPTION
# Motivations
I maintain a OpenAPI 3.x spec that I'd like to document with Fumadocs, however I utilize multiple tags on several operations for automatic documentation organization purposes

Redoc supports multiple tags in their documentation generation out-of-the-box, and I think Fumadocs could benefit from the same

# Modifications
- Write the file for every tag for a given operation for `groupBy: 'tag'`
- Add test and test fixture