### PR TITLE
Update comparisons.mdx. Update with Nextra 3 features

### DIFF
--- a/apps/docs/content/docs/ui/comparisons.mdx
+++ b/apps/docs/content/docs/ui/comparisons.mdx
@@ -43,7 +43,7 @@ adding it to an existing codebase or implementing advanced routing.
 | Full-text Search    | Yes          | Yes               |
 | i18n                | Yes          | Yes               |
 | Last Git Edit Time  | Yes          | Yes               |
-| Page Icons          | Yes          | No                |
+| Page Icons          | Yes          | Yes, via `_meta.js` files |
 | RSC                 | Yes          | Pages Router Only |
 | Remote Source       | Yes          | Yes               |
 | SEO                 | Via Metadata | Yes               |
@@ -58,7 +58,7 @@ Features supported via 3rd party libraries like [TypeDoc](https://typedoc.org) w
 | -------------------------- | -------- | ------ |
 | OpenAPI Integration        | Yes      | No     |
 | TypeScript Docs Generation | Yes      | No     |
-| TypeScript Twoslash        | Yes      | No     |
+| TypeScript Twoslash        | Yes      | Yes    |
 
 ## Mintlify
 


### PR DESCRIPTION
twoslash support was added in Nextra 3 and _meta.js files as well