### PR TITLE
Fix rendering of OpenAPI nullable defined with `allOf`.

### DIFF
--- a/.changeset/chatty-balloons-approve.md
+++ b/.changeset/chatty-balloons-approve.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-openapi": patch
+---
+
+Fix rendering of OpenAPI nullable defined with `allOf`.

--- a/packages/openapi/src/utils/combine-schema.ts
+++ b/packages/openapi/src/utils/combine-schema.ts
@@ -8,10 +8,14 @@ export function combineSchema(
   schema: OpenAPI.SchemaObject[],
 ): OpenAPI.SchemaObject {
   const result: OpenAPI.SchemaObject = {
-    type: 'object',
+    type: undefined,
   };
 
   function add(s: OpenAPI.SchemaObject): void {
+    if (s.type) {
+      result.type = result.type ? 'object' : s.type;
+    }
+
     if (s.properties) {
       result.properties ??= {};
       Object.assign(result.properties, s.properties);
@@ -30,6 +34,15 @@ export function combineSchema(
     if (s.required) {
       result.required ??= [];
       result.required.push(...s.required);
+    }
+
+    if (s.enum?.length > 0) {
+      result.enum ??= [];
+      result.enum.push(...s.enum);
+    }
+
+    if (s.nullable) {
+      result.nullable = true;
     }
 
     if (s.allOf) {

--- a/packages/openapi/src/utils/combine-schema.ts
+++ b/packages/openapi/src/utils/combine-schema.ts
@@ -36,7 +36,7 @@ export function combineSchema(
       result.required.push(...s.required);
     }
 
-    if (s.enum?.length > 0) {
+    if (s.enum && s.enum.length > 0) {
       result.enum ??= [];
       result.enum.push(...s.enum);
     }


### PR DESCRIPTION
Fixes https://github.com/fuma-nama/fumadocs/issues/1032

OpenAPI 3.0 marks an object as nullable by setting `nullable: true`. This can be set directly on the object, e.g.
```json
{
  "type": "string",
  "nullable": true
}
```

or it can be merged via `allOf`:

```json
{
  "allOf": [
    { "type": "string" },
    { "nullable": true },
  ]
}
```

The current fumadocs-openapi renderer treats `anyOf` as similar to a TypeScript `&` operator. For example, the `anyOf` above would be rendered as `string & null` when it should be `string | null`.

To do:

- [ ] run `pnpm changeset`