### PR TITLE
fix: make <Accordions /> 'type' prop optional

### DIFF
--- a/.changeset/dirty-geese-tickle.md
+++ b/.changeset/dirty-geese-tickle.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-ui': patch
+---
+
+made <Accordions /> 'type' prop optional

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -22,10 +22,10 @@ interface CustomProps {
 
 export const Accordions = forwardRef<
   HTMLDivElement,
-  (
-    | Omit<AccordionSingleProps, 'value' | 'onValueChange' | 'type'> & CustomProps
-    | Omit<AccordionMultipleProps, 'value' | 'onValueChange' | 'type'> & CustomProps
-  )
+  | (Omit<AccordionSingleProps, 'value' | 'onValueChange' | 'type'> &
+      CustomProps)
+  | (Omit<AccordionMultipleProps, 'value' | 'onValueChange' | 'type'> &
+      CustomProps)
 >(({ type = 'single', className, defaultValue, ...props }, ref) => {
   const [value, setValue] = useState<string | string[]>(
     type === 'single' ? (defaultValue ?? '') : (defaultValue ?? []),

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -16,10 +16,16 @@ import { cn } from '@/utils/cn';
 import { useCopyButton } from '@/utils/use-copy-button';
 import { buttonVariants } from '@/components/ui/button';
 
+interface CustomProps {
+  type?: 'single' | 'multiple';
+}
+
 export const Accordions = forwardRef<
   HTMLDivElement,
-  | Omit<AccordionSingleProps, 'value' | 'onValueChange'>
-  | Omit<AccordionMultipleProps, 'value' | 'onValueChange'>
+  (
+    | Omit<AccordionSingleProps, 'value' | 'onValueChange' | 'type'> & CustomProps
+    | Omit<AccordionMultipleProps, 'value' | 'onValueChange' | 'type'> & CustomProps
+  )
 >(({ type = 'single', className, defaultValue, ...props }, ref) => {
   const [value, setValue] = useState<string | string[]>(
     type === 'single' ? (defaultValue ?? '') : (defaultValue ?? []),


### PR DESCRIPTION
The [documentation for accordian](https://fumadocs.vercel.app/docs/ui/components/accordion) has the following as the example usage:

```mdx
<Accordions>
  <Accordion title="My Title">My Content</Accordion>
</Accordions>
```

However, this resulted in the error:
<img width="820" alt="image" src="https://github.com/user-attachments/assets/0deb777c-0b06-4c7b-89a9-3d5cc632a7e3">


<details closed>
<summary>Raw Error</summary>

```
Type '{ children: Element; }' is not assignable to type 'IntrinsicAttributes & ((Omit<AccordionSingleProps, "value" | "onValueChange"> | Omit<AccordionMultipleProps, "value" | "onValueChange">) & RefAttributes<...>)'.
  Property 'type' is missing in type '{ children: Element; }' but required in type 'Omit<AccordionMultipleProps, "value" | "onValueChange">'.ts(2322)
index.d.mts(23, 5): 'type' is declared here.
(alias) const Accordions: ForwardRefExoticComponent<(Omit<AccordionSingleProps, "value" | "onValueChange"> | Omit<AccordionMultipleProps, "value" | "onValueChange">) & RefAttributes<...>>
import Accordions
```

</details>

This PR makes the accordion type optional. I've defined `CustomProps` for now, and plan to add the `updateAnchor` option similar to the <Tabs /> component in #1070 



