### PR TITLE
UI: Fix nav height

### DIFF
--- a/packages/ui/src/layouts/home.tsx
+++ b/packages/ui/src/layouts/home.tsx
@@ -53,7 +53,7 @@ export function HomeLayout(props: HomeLayoutProps) {
         id="nd-home-layout"
         {...rest}
         className={cn(
-          'flex flex-1 flex-col pt-[var(--fd-nav-height)] [--fd-nav-height:56px]',
+          'flex flex-1 flex-col pt-[var(--fd-nav-height)] [--fd-nav-height:57px]',
           rest.className,
         )}
       >


### PR DESCRIPTION
Fixed --fd-nav-height default from 56px to 57px because it was short by one pixel

Before:
<img width="806" alt="Screenshot 2025-01-08 at 21 30 13" src="https://github.com/user-attachments/assets/dfae1f5b-b6be-4b93-bae7-e7a4b81aeb65" />

After:
<img width="792" alt="Screenshot 2025-01-08 at 22 03 11" src="https://github.com/user-attachments/assets/a8809a47-2d3c-4a74-874a-10cdd8651c29" />
