### PR TITLE
UI: fix navbar height for header borders

### DIFF
--- a/packages/ui/src/layouts/home/navbar.tsx
+++ b/packages/ui/src/layouts/home/navbar.tsx
@@ -40,7 +40,7 @@ export function Navbar(props: HTMLAttributes<HTMLElement>) {
           props.className,
         )}
       >
-        <nav className="flex h-[56px] w-full flex-row items-center gap-6 px-4 lg:h-12">
+        <nav className="flex h-[56px] w-full flex-row items-center gap-6 px-4 lg:h-[46px]">
           {props.children}
         </nav>
         <NavigationMenuViewport />

--- a/packages/ui/src/layouts/home/navbar.tsx
+++ b/packages/ui/src/layouts/home/navbar.tsx
@@ -40,7 +40,7 @@ export function Navbar(props: HTMLAttributes<HTMLElement>) {
           props.className,
         )}
       >
-        <nav className="flex h-14 w-full flex-row items-center gap-6 px-4 lg:h-12">
+        <nav className="flex h-[56px] w-full flex-row items-center gap-6 px-4 lg:h-12">
           {props.children}
         </nav>
         <NavigationMenuViewport />


### PR DESCRIPTION
It is my mistake about the pull request #1251 the problem was elsewhere.

The height of the header overlaps the main content by 1 pixel in mobile view and 2 pixels in desktop view (border all around the header) due to the fact that the border is not taken into account when setting the height of the nav in this component. I suggest this fix with hard coded heights but you are free to fix another way if you want.

Before:
<img width="997" alt="Screenshot 2025-01-09 at 01 16 48" src="https://github.com/user-attachments/assets/d713a106-5486-448b-901e-7f862c1727b1" />

After:
<img width="1004" alt="Screenshot 2025-01-09 at 01 16 42" src="https://github.com/user-attachments/assets/7b479dc9-5fb4-4187-9cc4-e04a8076b9db" />
