### PR TITLE
UI: Add Package Manager Tabs for OpenAPI and Open Graph

### DIFF
--- a/apps/docs/content/docs/ui/(integrations)/open-graph.mdx
+++ b/apps/docs/content/docs/ui/(integrations)/open-graph.mdx
@@ -16,9 +16,25 @@ For docs pages, Fumadocs has a built-in metadata image generator.
 
 ### Auto Setup
 
-```bash
+<Tabs groupId='package-manager' persist items={['npm', 'pnpm', 'yarn', 'bun']}>
+
+```bash tab="npm"
+npx fumadocs init og-image
+```
+
+```bash tab="pnpm"
 pnpm fumadocs init og-image
 ```
+
+```bash tab="yarn"
+yarn fumadocs init og-image
+```
+
+```bash tab="bun"
+bun fumadocs init og-image
+```
+
+</Tabs>
 
 ### Manual Setup
 

--- a/apps/docs/content/docs/ui/(integrations)/openapi/index.mdx
+++ b/apps/docs/content/docs/ui/(integrations)/openapi/index.mdx
@@ -9,12 +9,37 @@ You can setup Fumadocs OpenAPI manually, or use Fumadocs CLI.
 
 Using Fumadocs CLI.
 
-```bash
+<Tabs groupId='package-manager' persist items={['npm', 'pnpm', 'yarn', 'bun']}>
+
+```bash tab="npm"
+# install the CLI package, if you haven't installed it yet
+npm install @fumadocs/cli --save-dev
+
+npx fumadocs init openapi
+```
+
+```bash tab="pnpm"
 # install the CLI package, if you haven't installed it yet
 pnpm add @fumadocs/cli --save-dev
 
 pnpm fumadocs init openapi
 ```
+
+```bash tab="yarn"
+# install the CLI package, if you haven't installed it yet
+yarn add @fumadocs/cli ---dev
+
+yarn fumadocs init openapi
+```
+
+```bash tab="bun"
+# install the CLI package, if you haven't installed it yet
+bun add @fumadocs/cli ---dev
+
+bun fumadocs init openapi
+```
+
+</Tabs>
 
 ## Manual Setup
 


### PR DESCRIPTION
This pull request updates the documentation UI by adding tabs for different package managers to the OpenAPI and the Open Graph installation instructions.

OpenAPI Before:
![image](https://github.com/user-attachments/assets/c29c9550-81c2-480d-8dfc-1a850aca41d0)

OpenAPI After:
![image](https://github.com/user-attachments/assets/90ca78f1-68f3-49b4-ba7b-b5778962b2bd)

