### PR TITLE
UI: fix tagslist not wrapping

### DIFF
--- a/packages/ui/src/components/dialog/search.tsx
+++ b/packages/ui/src/components/dialog/search.tsx
@@ -313,7 +313,7 @@ export function TagsList({
   return (
     <div
       {...props}
-      className={cn('flex flex-row items-center gap-1', props.className)}
+      className={cn('flex flex-row items-center gap-1 flex-wrap', props.className)}
     >
       {items.map((item) => (
         <button


### PR DESCRIPTION
This fixes an issue where the tagslist will overflow when there are too much tags.

<img width="853" alt="image" src="https://github.com/user-attachments/assets/01633c5f-e7eb-44f4-bf84-4585aa5d5e1b" />
