### PR TITLE
Docs: Fix Typo in `Tab` Docs

### DIFF
--- a/apps/docs/content/docs/ui/components/tabs.mdx
+++ b/apps/docs/content/docs/ui/components/tabs.mdx
@@ -45,7 +45,7 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 ### Shared Value
 
-By passing an `id` property, you can share a value across all tabs with the same
+By passing an `groupId` property, you can share a value across all tabs with the same
 id.
 
 ```mdx


### PR DESCRIPTION
Fix typo from `id` to `groupId`