### PR TITLE
Feat: support multiple examples in openapi operation #1370

### DIFF
--- a/.changeset/metal-cherries-ring.md
+++ b/.changeset/metal-cherries-ring.md
@@ -1,0 +1,8 @@
+---
+"fumadocs-openapi": patch
+"docs": minor
+---
+
+Feat: support multiple examples in openapi operation #1370
+
+Adds two new options to the ApiExample renderer "Samples" and "Sample"

--- a/apps/docs/museum.yaml
+++ b/apps/docs/museum.yaml
@@ -67,6 +67,10 @@ paths:
             examples:
               default_example:
                 $ref: '#/components/examples/CreateSpecialEventRequestExample'
+              secondary_example:
+                $ref: '#/components/examples/SecondaryCreateSpecialEventRequestExample'
+              tertiary_example:
+                $ref: '#/components/examples/TertiaryCreateSpecialEventRequestExample'
       responses:
         '201':
           description: Created.
@@ -464,7 +468,8 @@ components:
         ticketDate: '2023-09-05'
         confirmationCode: ticket-event-9c55eg-8v82a
     CreateSpecialEventRequestExample:
-      summary: Create special event
+      summary: Create special event 1
+      description: Example with no price.
       value:
         name: Mermaid Treasure Identification and Analysis
         location: Under the seaaa 🦀 🎶 🌊.
@@ -473,6 +478,28 @@ components:
           - '2023-09-05'
           - '2023-09-08'
         price: 0
+    SecondaryCreateSpecialEventRequestExample:
+      summary: Create special event 2
+      description: Example with a price.
+      value:
+        name: Mermaid Treasure Identification and Analysis
+        location: Under the seaaa 🦀 🎶 🌊.
+        eventDescription: Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits, kindly donated by Ariel.
+        dates:
+          - '2023-09-05'
+          - '2023-09-08'
+        price: 1234
+    TertiaryCreateSpecialEventRequestExample:
+      summary: Create special event 3 and a dang long title
+      description: Example with a price.
+      value:
+        name: Mermaid Treasure Identification and Analysis
+        location: Under the seaaa 🦀 🎶 🌊.
+        eventDescription: Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits, kindly donated by Ariel.
+        dates:
+          - '2023-09-05'
+          - '2023-09-08'
+        price: 1234
     CreateSpecialEventResponseExample:
       summary: Special event created
       value:

--- a/packages/openapi/src/render/operation.tsx
+++ b/packages/openapi/src/render/operation.tsx
@@ -48,6 +48,8 @@ export function Operation({
   ctx,
   hasHead,
   headingLevel = 2,
+  selectedSampleKey,
+  exclusiveSampleKey,
 }: {
   type?: 'webhook' | 'operation';
   path: string;
@@ -56,6 +58,8 @@ export function Operation({
 
   hasHead?: boolean;
   headingLevel?: number;
+  selectedSampleKey?: string;
+  exclusiveSampleKey?: string;
 }): ReactElement {
   const body = method.requestBody;
   const security = method.security ?? ctx.schema.document.security;
@@ -230,7 +234,13 @@ export function Operation({
     return (
       <ctx.renderer.API>
         {info}
-        <APIExample method={method} endpoint={endpoint} ctx={ctx} />
+        <APIExample
+          method={method}
+          endpoint={endpoint}
+          ctx={ctx}
+          selectedSampleKey={selectedSampleKey}
+          exclusiveSampleKey={exclusiveSampleKey}
+        />
       </ctx.renderer.API>
     );
   } else {
@@ -266,11 +276,13 @@ async function APIExample({
   endpoint,
   ctx,
   selectedSampleKey,
+  exclusiveSampleKey,
 }: {
   method: MethodInformation;
   endpoint: EndpointSample;
   ctx: RenderContext;
   selectedSampleKey?: string;
+  exclusiveSampleKey?: string;
 }) {
   const renderer = ctx.renderer;
   const children: ReactNode[] = [];
@@ -303,19 +315,22 @@ async function APIExample({
     const sampleTabs: ReactNode[] = [];
     const titles = [];
     if (
-      endpoint.body?.samples &&
-      Object.keys(endpoint.body?.samples).length === 1 &&
-      endpoint.body?.samples['_default']
+      (endpoint.body?.samples &&
+        Object.keys(endpoint.body?.samples).length === 1 &&
+        endpoint.body?.samples['_default']) ||
+      (exclusiveSampleKey && endpoint.body?.samples[exclusiveSampleKey])
     ) {
-      // if only the fallback or non described openapi legacy example is present, we dont use tabs
+      // if exclusiveSampleKey is present, we don't use tabs
+      // if only the fallback or non described openapi legacy example is present, we don't use tabs
+      const sampleKey = exclusiveSampleKey ?? '_default';
       children.push(
         <renderer.Requests
-          key={`requests-${'_default'}`}
-          items={samples['_default'].map((s) => s.label)}
+          key={`requests-${sampleKey}`}
+          items={samples[sampleKey].map((s) => s.label)}
         >
-          {samples['_default'].map((s) => (
+          {samples[sampleKey].map((s) => (
             <renderer.Request
-              key={`requests-${'_default'}-${s.label}`}
+              key={`requests-${sampleKey}-${s.label}`}
               name={s.label}
               code={s.source}
               language={s.lang}

--- a/packages/openapi/src/render/renderer.tsx
+++ b/packages/openapi/src/render/renderer.tsx
@@ -50,6 +50,16 @@ export interface RequestProps {
   code: string;
 }
 
+export interface SampleProps {
+  value: string;
+  children: ReactNode;
+}
+export interface SamplesProps {
+  items: string[];
+  children: ReactNode;
+  defaultValue?: string;
+}
+
 export interface ResponseTypeProps {
   lang: string;
   code: string;
@@ -70,6 +80,8 @@ export interface Renderer {
 
   Responses: ComponentType<ResponsesProps>;
   Response: ComponentType<ResponseProps>;
+  Sample: ComponentType<SampleProps>;
+  Samples: ComponentType<SamplesProps>;
   Requests: ComponentType<{ items: string[]; children: ReactNode }>;
   Request: ComponentType<RequestProps>;
   ResponseTypes: ComponentType<{ children: ReactNode }>;
@@ -132,6 +144,9 @@ export function createRenders(
     Requests: (props) => (
       <Tabs groupId="fumadocs_openapi_requests" {...props} />
     ),
+    Samples: (props) => <Tabs groupId="fumadocs_openapi_samples" {...props} />,
+    Sample: Tab,
+
     Request: (props) => (
       <Tab value={props.name}>
         <CodeBlock

--- a/packages/openapi/src/render/renderer.tsx
+++ b/packages/openapi/src/render/renderer.tsx
@@ -144,7 +144,7 @@ export function createRenders(
     Requests: (props) => (
       <Tabs groupId="fumadocs_openapi_requests" {...props} />
     ),
-    Samples: (props) => <Tabs groupId="fumadocs_openapi_samples" {...props} />,
+    Samples: (props) => <Tabs {...props} />,
     Sample: Tab,
 
     Request: (props) => (

--- a/packages/openapi/src/requests/curl.ts
+++ b/packages/openapi/src/requests/curl.ts
@@ -1,7 +1,10 @@
 import { type EndpointSample } from '@/utils/generate-sample';
 import { inputToString } from '@/utils/input-to-string';
 
-export function getSampleRequest(endpoint: EndpointSample): string {
+export function getSampleRequest(
+  endpoint: EndpointSample,
+  sampleKey: string,
+): string {
   const s: string[] = [];
 
   s.push(`curl -X ${endpoint.method} "${endpoint.url}"`);
@@ -21,7 +24,7 @@ export function getSampleRequest(endpoint: EndpointSample): string {
   }
 
   if (endpoint.body?.mediaType === 'multipart/form-data') {
-    const sample = endpoint.body.sample;
+    const sample = endpoint.body.samples[sampleKey]?.value;
 
     if (sample && typeof sample === 'object') {
       for (const [key, value] of Object.entries(sample)) {
@@ -31,7 +34,7 @@ export function getSampleRequest(endpoint: EndpointSample): string {
   } else if (endpoint.body) {
     s.push(`-H "Content-Type: ${endpoint.body.mediaType}"`);
     s.push(
-      `-d ${inputToString(endpoint.body.sample, endpoint.body.mediaType, 'single-quote')}`,
+      `-d ${inputToString(endpoint.body.samples[sampleKey]?.value ?? '', endpoint.body.mediaType, 'single-quote')}`,
     );
   }
 

--- a/packages/openapi/src/requests/go.ts
+++ b/packages/openapi/src/requests/go.ts
@@ -1,7 +1,10 @@
 import { type EndpointSample } from '@/utils/generate-sample';
 import { inputToString } from '@/utils/input-to-string';
 
-export function getSampleRequest(endpoint: EndpointSample): string {
+export function getSampleRequest(
+  endpoint: EndpointSample,
+  sampleKey: string,
+): string {
   const imports = ['fmt', 'net/http', 'io/ioutil'];
   const headers = new Map<string, string>();
   const variables = new Map<string, string>();
@@ -28,14 +31,16 @@ export function getSampleRequest(endpoint: EndpointSample): string {
 
     if (
       endpoint.body.mediaType === 'multipart/form-data' &&
-      typeof endpoint.body.sample === 'object'
+      typeof endpoint.body.samples[sampleKey]?.value === 'object'
     ) {
       imports.push('mime/multipart', 'bytes');
 
       variables.set('payload', `new(bytes.Buffer)`);
       variables.set('mp', 'multipart.NewWriter(payload)');
 
-      for (const [key, value] of Object.entries(endpoint.body.sample ?? {})) {
+      for (const [key, value] of Object.entries(
+        endpoint.body.samples[sampleKey]?.value ?? {},
+      )) {
         additional.push(
           `mp.WriteField("${key}", ${inputToString(value, undefined, 'backtick')})`,
         );
@@ -45,7 +50,7 @@ export function getSampleRequest(endpoint: EndpointSample): string {
       variables.set(
         'payload',
         `strings.NewReader(${inputToString(
-          endpoint.body.sample,
+          endpoint.body.samples[sampleKey]?.value ?? '',
           endpoint.body.mediaType,
           'backtick',
         ).replaceAll('\n', '\n  ')})`,

--- a/packages/openapi/src/requests/javascript.ts
+++ b/packages/openapi/src/requests/javascript.ts
@@ -1,7 +1,10 @@
 import { type EndpointSample } from '@/utils/generate-sample';
 import { inputToString } from '@/utils/input-to-string';
 
-export function getSampleRequest(endpoint: EndpointSample): string {
+export function getSampleRequest(
+  endpoint: EndpointSample,
+  sampleKey: string,
+): string {
   const s: string[] = [];
   const options = new Map<string, string>();
   const headers = new Map<string, unknown>();
@@ -38,12 +41,14 @@ export function getSampleRequest(endpoint: EndpointSample): string {
 
   if (
     endpoint.body?.mediaType === 'multipart/form-data' &&
-    typeof endpoint.body.sample === 'object' &&
-    endpoint.body.sample
+    typeof endpoint.body.samples[sampleKey]?.value === 'object' &&
+    endpoint.body.samples[sampleKey]?.value
   ) {
     s.push(`const formData = new FormData();`);
 
-    for (const [key, value] of Object.entries(endpoint.body.sample))
+    for (const [key, value] of Object.entries(
+      endpoint.body.samples[sampleKey]?.value,
+    ))
       s.push(`formData.set(${key}, ${inputToString(value)})`);
 
     options.set('body', 'formData');
@@ -52,16 +57,16 @@ export function getSampleRequest(endpoint: EndpointSample): string {
 
     if (endpoint.body.mediaType === 'application/json') {
       code =
-        typeof endpoint.body.sample === 'string'
+        typeof endpoint.body.samples[sampleKey]?.value === 'string'
           ? inputToString(
-              endpoint.body.sample,
+              endpoint.body.samples[sampleKey]?.value,
               endpoint.body.mediaType,
               'backtick',
             )
-          : `JSON.stringify(${JSON.stringify(endpoint.body.sample, null, 2)})`;
+          : `JSON.stringify(${JSON.stringify(endpoint.body.samples[sampleKey]?.value, null, 2)})`;
     } else {
       code = inputToString(
-        endpoint.body.sample,
+        endpoint.body.samples[sampleKey]?.value ?? '',
         endpoint.body.mediaType,
         'backtick',
       );

--- a/packages/openapi/src/requests/python.ts
+++ b/packages/openapi/src/requests/python.ts
@@ -1,7 +1,10 @@
 import { type EndpointSample } from '@/utils/generate-sample';
 import { inputToString } from '@/utils/input-to-string';
 
-export function getSampleRequest(endpoint: EndpointSample): string {
+export function getSampleRequest(
+  endpoint: EndpointSample,
+  sampleKey: string,
+): string {
   const headers = new Map<string, unknown>();
   const cookies = new Map<string, unknown>();
   const variables = new Map<string, string>();
@@ -14,11 +17,25 @@ export function getSampleRequest(endpoint: EndpointSample): string {
   if (endpoint.body) {
     switch (endpoint.body.mediaType) {
       case 'application/json':
-        variables.set('json', JSON.stringify(endpoint.body.sample, null, 2));
+        variables.set(
+          'json',
+          JSON.stringify(
+            endpoint.body.samples[sampleKey]?.value ?? {},
+            null,
+            2,
+          ),
+        );
         break;
       case 'multipart/form-data':
         headers.set('Content-Type', endpoint.body.mediaType);
-        variables.set('data', JSON.stringify(endpoint.body.sample, null, 2));
+        variables.set(
+          'data',
+          JSON.stringify(
+            endpoint.body.samples[sampleKey]?.value ?? {},
+            null,
+            2,
+          ),
+        );
         break;
       default:
         headers.set('Content-Type', endpoint.body.mediaType);
@@ -26,7 +43,7 @@ export function getSampleRequest(endpoint: EndpointSample): string {
         variables.set(
           'data',
           inputToString(
-            endpoint.body.sample,
+            endpoint.body.samples[sampleKey]?.value ?? '',
             endpoint.body.mediaType,
             'backtick',
           ),

--- a/packages/openapi/src/server/api-page.tsx
+++ b/packages/openapi/src/server/api-page.tsx
@@ -47,6 +47,14 @@ export interface WebhookItem {
 export interface OperationItem {
   path: string;
   method: OpenAPIV3_1.HttpMethods;
+  /**
+   * The key of the sample to be selected
+   */
+  selectedSampleKey?: string;
+  /**
+   * Only this sample will be shown
+   */
+  exclusiveSampleKey?: string;
 }
 
 export async function APIPage(props: ApiPageProps) {
@@ -79,6 +87,8 @@ export async function APIPage(props: ApiPageProps) {
             path={item.path}
             ctx={ctx}
             hasHead={hasHead}
+            selectedSampleKey={item.selectedSampleKey}
+            exclusiveSampleKey={item.exclusiveSampleKey}
           />
         );
       })}

--- a/packages/openapi/src/utils/generate-sample.ts
+++ b/packages/openapi/src/utils/generate-sample.ts
@@ -19,7 +19,14 @@ export interface EndpointSample {
   body?: {
     schema: ParsedSchema;
     mediaType: string;
-    sample: unknown;
+    samples: {
+      [key: string]: {
+        value?: unknown;
+        description?: string;
+        summary?: string;
+        externalValue?: string;
+      };
+    };
   };
   responses: Record<string, ResponseSample>;
   parameters: ParameterSample[];
@@ -102,7 +109,13 @@ export function generateSample(
     bodyOutput = {
       schema,
       mediaType: type as string,
-      sample: body[type].example ?? generateBody(method.method, schema),
+      samples: body[type].examples
+        ? body[type].examples
+        : {
+            _default: {
+              value: body[type].example ?? generateBody(method.method, schema),
+            },
+          },
     };
   }
 

--- a/packages/openapi/src/utils/generate-sample.ts
+++ b/packages/openapi/src/utils/generate-sample.ts
@@ -6,7 +6,14 @@ import {
   type NoReference,
 } from '@/utils/schema';
 import { getSecurities, getSecurityPrefix } from '@/utils/get-security';
-
+export interface EndpointSamples {
+  [key: string]: {
+    value?: unknown;
+    description?: string;
+    summary?: string;
+    externalValue?: string;
+  };
+}
 /**
  * Sample info of endpoint
  */
@@ -19,14 +26,7 @@ export interface EndpointSample {
   body?: {
     schema: ParsedSchema;
     mediaType: string;
-    samples: {
-      [key: string]: {
-        value?: unknown;
-        description?: string;
-        summary?: string;
-        externalValue?: string;
-      };
-    };
+    samples: EndpointSamples;
   };
   responses: Record<string, ResponseSample>;
   parameters: ParameterSample[];

--- a/packages/openapi/test/code-sample.test.ts
+++ b/packages/openapi/test/code-sample.test.ts
@@ -40,27 +40,39 @@ describe('Code Sample Generators', () => {
       const endpoint = generateSample(path, info, ctx);
 
       test(`Go: ${method} ${path}`, async () => {
-        await expect(Go.getSampleRequest(endpoint)).toMatchFileSnapshot(
-          `./out/samples/${path}/${method}.go`,
-        );
+        await expect(
+          Go.getSampleRequest(
+            endpoint,
+            Object.keys(endpoint.body?.samples ?? {})[0],
+          ),
+        ).toMatchFileSnapshot(`./out/samples/${path}/${method}.go`);
       });
 
       test(`Curl: ${method} ${path}`, async () => {
-        await expect(Curl.getSampleRequest(endpoint)).toMatchFileSnapshot(
-          `./out/samples/${path}/${method}.bash`,
-        );
+        await expect(
+          Curl.getSampleRequest(
+            endpoint,
+            Object.keys(endpoint.body?.samples ?? {})[0],
+          ),
+        ).toMatchFileSnapshot(`./out/samples/${path}/${method}.bash`);
       });
 
       test(`Python: ${method} ${path}`, async () => {
-        await expect(Python.getSampleRequest(endpoint)).toMatchFileSnapshot(
-          `./out/samples/${path}/${method}.py`,
-        );
+        await expect(
+          Python.getSampleRequest(
+            endpoint,
+            Object.keys(endpoint.body?.samples ?? {})[0],
+          ),
+        ).toMatchFileSnapshot(`./out/samples/${path}/${method}.py`);
       });
 
       test(`JavaScript: ${method} ${path}`, async () => {
-        await expect(JS.getSampleRequest(endpoint)).toMatchFileSnapshot(
-          `./out/samples/${path}/${method}.js`,
-        );
+        await expect(
+          JS.getSampleRequest(
+            endpoint,
+            Object.keys(endpoint.body?.samples ?? {})[0],
+          ),
+        ).toMatchFileSnapshot(`./out/samples/${path}/${method}.js`);
       });
     }
   }

--- a/packages/openapi/test/fixtures/museum.yaml
+++ b/packages/openapi/test/fixtures/museum.yaml
@@ -58,6 +58,8 @@ paths:
             examples:
               default_example:
                 $ref: '#/components/examples/CreateSpecialEventRequestExample'
+              seconday_example:
+                $ref: '#/components/examples/SecondaryCreateSpecialEventRequestExample'
       responses:
         '200':
           description: Success
@@ -454,6 +456,7 @@ components:
         confirmationCode: ticket-event-9c55eg-8v82a
     CreateSpecialEventRequestExample:
       summary: Create special event
+      description: Create a special event for the museum.
       value:
         name: Mermaid Treasure Identification and Analysis
         location: Under the seaaa 🦀 🎶 🌊.
@@ -462,6 +465,17 @@ components:
           - 2023-09-05
           - 2023-09-08
         price: 0
+    SecondaryCreateSpecialEventRequestExample:
+      summary: Create special event with price
+      description: Create a special event with a price.
+      value:
+        name: Mermaid Treasure Identification and Analysis
+        location: Under the seaaa 🦀 🎶 🌊.
+        eventDescription: Join us as we review and classify a rare collection of 20 thingamabobs, gadgets, gizmos, whoosits, and whatsits, kindly donated by Ariel.
+        dates:
+          - 2023-09-05
+          - 2023-09-08
+        price: 1234
     CreateSpecialEventResponseExample:
       summary: Special event created
       value:


### PR DESCRIPTION
Implements changes discussed in #1370 

Changes:
- show tabs if there are named examples
- show summary of examples as tab title
- show description of examples rendered as markdown

<img width="613" alt="image" src="https://github.com/user-attachments/assets/e21fd942-9b67-46e7-bdb4-0969e6dfcf65" />
