### PR TITLE
Fix: Hide the server select panel, not just the select, if no or only one server is present

### DIFF
--- a/.changeset/spotty-buckets-nail.md
+++ b/.changeset/spotty-buckets-nail.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-openapi": patch
+---
+
+Fix: Hide the server select panel, not just the select, if no or only one server is present

--- a/packages/openapi/src/ui/playground/index.tsx
+++ b/packages/openapi/src/ui/playground/index.tsx
@@ -106,7 +106,7 @@ export function APIPlayground({
     ResultDisplay: FC<{ data: FetchResult }>;
   }>;
 } & HTMLAttributes<HTMLFormElement>) {
-  const { serverRef } = useApiContext();
+  const { serverRef, servers } = useApiContext();
   const dynamicRef = useRef(new Map<string, DynamicField>());
   const form = useForm<FormValues>({
     defaultValues: {
@@ -244,9 +244,11 @@ export function APIPlayground({
             route={route}
             isLoading={testQuery.isLoading}
           />
-          <CollapsiblePanel title="Server URL">
-            <ServerSelect />
-          </CollapsiblePanel>
+          {servers.length > 1 ? (
+            <CollapsiblePanel title="Server URL">
+              <ServerSelect />
+            </CollapsiblePanel>
+          ) : null}
 
           {header.length > 0 || authorization ? (
             <CollapsiblePanel title="Headers">


### PR DESCRIPTION
Hide the server select panel not just the select if no or only one server is present.

Changes: 
fix(packages/openapi): only show server select panel if servers exist