### PR TITLE
fix: openapi - preserve <> placeholder marker for params with no example value

### DIFF
--- a/.changeset/funny-kangaroos-do.md
+++ b/.changeset/funny-kangaroos-do.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-openapi": patch
+---
+
+fix: openapi - preserve <> placeholder marker for params with no example value

--- a/packages/openapi/src/utils/generate-sample.ts
+++ b/packages/openapi/src/utils/generate-sample.ts
@@ -48,11 +48,16 @@ export function generateSample(
 
   for (const param of method.parameters ?? []) {
     if (param.schema) {
+      let value = param.example ?? sample(param.schema as object);
+      if (param.schema.type && param.schema.type === value) {
+        // if no example is defined make sure its visible that there is still a placeholder, equal to auth <token>
+        value = `<${value}>`;
+      }
       params.push({
         name: param.name,
         in: param.in,
         schema: param.schema,
-        sample: param.example ?? sample(param.schema as object),
+        sample: value,
       });
     } else if (param.content) {
       const key = getPreferredType(param.content);
@@ -129,7 +134,11 @@ export function generateSample(
   const queryParams = new URLSearchParams();
 
   for (const param of params) {
-    const value = generateBody(method.method, param.schema);
+    let value = generateBody(method.method, param.schema);
+    if (param.schema.type && param.schema.type === value) {
+      // if no example is defined make sure its visible that there is still a placeholder, equal to auth <token>
+      value = `<${value}>`;
+    }
     if (param.in === 'query') queryParams.append(param.name, String(value));
 
     if (param.in === 'path')
@@ -143,7 +152,7 @@ export function generateSample(
     pathWithParameters = `${pathWithParameters}?${queryParams.toString()}`;
 
   return {
-    url: new URL(`${baseUrl}${pathWithParameters}`).toString(),
+    url: `${baseUrl}${pathWithParameters}`,
     body: bodyOutput,
     responses,
     method: method.method,


### PR DESCRIPTION
If no example value is defined for a parameter, keep the <> markers in the examples so that they are visible to the user.

changes:
- fix(packages/openapi): preserve <> placeholder marker for params with no example value

<img width="808" alt="image" src="https://github.com/user-attachments/assets/e887ae62-4503-4af4-8f9f-ae8b3190bb68" />
