### PR TITLE
fix(packages/openapi): hide AuthSection is security is an empty array

### DIFF
--- a/.changeset/bright-jokes-sneeze.md
+++ b/.changeset/bright-jokes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-openapi": patch
+---
+
+fix(packages/openapi): hide AuthSection is security is an empty array

--- a/packages/openapi/src/render/operation.tsx
+++ b/packages/openapi/src/render/operation.tsx
@@ -203,7 +203,7 @@ export function Operation({
       {type === 'operation' ? (
         <ctx.renderer.APIPlayground path={path} method={method} ctx={ctx} />
       ) : null}
-      {security ? (
+      {security && Object.keys(security).length ? (
         <>
           {heading(headingLevel, 'Authorization', ctx)}
           <AuthSection requirements={security} ctx={ctx} />

--- a/packages/openapi/src/render/operation.tsx
+++ b/packages/openapi/src/render/operation.tsx
@@ -203,7 +203,7 @@ export function Operation({
       {type === 'operation' ? (
         <ctx.renderer.APIPlayground path={path} method={method} ctx={ctx} />
       ) : null}
-      {security && Object.keys(security).length ? (
+      {security && Object.keys(security).length > 0 ? (
         <>
           {heading(headingLevel, 'Authorization', ctx)}
           <AuthSection requirements={security} ctx={ctx} />


### PR DESCRIPTION
Hides Authorization if security config is empty, for example if there is a global default that's overwritten to empty (ie. webhooks)

Changes:
- fix(packages/openapi): hide AuthSection is security is an empty array