### PR TITLE
OpenAPI: Improve display for anyOf schema type

### DIFF
--- a/packages/openapi/src/render/schema.tsx
+++ b/packages/openapi/src/render/schema.tsx
@@ -259,10 +259,16 @@ function getSchemaType(
   if (schema.not) return `not ${getSchemaType(schema.not, ctx, false)}`;
 
   if (schema.anyOf) {
-    return `Any properties in ${schema.anyOf
+    const properties = schema.anyOf
       .map((one) => getSchemaType(one, ctx, false))
-      .filter((v) => v !== 'unknown')
-      .join(', ')}`;
+      .filter((v) => v !== 'unknown');
+
+    if (properties.length > 1) {
+      return `Any properties in ${properties.join(',')}`;
+    } else if (properties.length === 1) {
+      return properties[0];
+    }
+    // otherwise unknown
   }
 
   if (schema.type === 'string' && schema.format === 'binary' && ctx.allowFile)


### PR DESCRIPTION
In OpenAPI V3.1 optional fields are commonly specified as `anyOf` in schema.

Example:
```json
"cursor": {"anyOf": [{"type": "string"}, {"type": "null"}]
```

this leads to sub-optimal display of types in docs:

<img width="735" alt="Screenshot 2025-02-13 at 15 40 43" src="https://github.com/user-attachments/assets/567128da-9a58-460a-b661-4a9f6c8e4418" />

This PR shows only the type option in case there is only one option to show.

<img width="750" alt="Screenshot 2025-02-13 at 15 36 00" src="https://github.com/user-attachments/assets/67920fdd-7452-406a-969c-c010265aed47" />

