### PR TITLE
docs: fix pnpm command

### DIFF
--- a/apps/docs/content/docs/ui/(integrations)/open-graph.mdx
+++ b/apps/docs/content/docs/ui/(integrations)/open-graph.mdx
@@ -23,7 +23,7 @@ npx fumadocs init og-image
 ```
 
 ```bash tab="pnpm"
-pnpm fumadocs init og-image
+pnpm dlx fumadocs init og-image
 ```
 
 ```bash tab="yarn"


### PR DESCRIPTION
When executing the pnpm comand it returns an error (see image below). Adding `dlx` fix the error.

![image](https://github.com/user-attachments/assets/781d241d-4554-4afa-a03d-ce39e88804b0)
