### PR TITLE
(docs) fix: deadlink in customisation.mdx

### DIFF
--- a/apps/docs/content/docs/ui/customisation.mdx
+++ b/apps/docs/content/docs/ui/customisation.mdx
@@ -36,7 +36,7 @@ You can use the exposed options of different layouts:
   <Card title="Notebook Layout" href="/docs/ui/layouts/notebook">
     A more compact version of Docs Layout
   </Card>
-  <Card title="Home Layout" href="/docs/ui/layouts/home">
+  <Card title="Home Layout" href="/docs/ui/layouts/home-layout">
     Layout for other pages
   </Card>
 </Cards>


### PR DESCRIPTION
This card links to https://fumadocs.vercel.app/docs/ui/layouts/home (404)
<img width="397" alt="Screenshot 2025-03-25 at 1 23 10 AM" src="https://github.com/user-attachments/assets/0e253a6c-76d8-4d45-8323-ad09055a94eb" />
when it should be https://fumadocs.vercel.app/docs/ui/layouts/home-layout