### PR TITLE
UI: Use `text.previousPage` for previous page navigation

### DIFF
--- a/.changeset/five-pears-sort.md
+++ b/.changeset/five-pears-sort.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-ui": patch
+---
+
+UI: Use `text.previousPage` for previous page navigation

--- a/packages/ui/src/page-client.tsx
+++ b/packages/ui/src/page-client.tsx
@@ -209,7 +209,7 @@ function FooterItem({ item, index }: { item: Item; index: 0 | 1 }) {
         )}
       >
         <Icon className="-mx-1 size-4 shrink-0 rtl:rotate-180" />
-        <p>{title ?? text.nextPage}</p>
+        <p>{title ?? (index == 0 ? text.previousPage : text.nextPage) }</p>
       </div>
       <p
         className={cn(


### PR DESCRIPTION
Currently, in the footer navigation, if the description is not present, the button to go to the previous page is labeled "Next".
![image](https://github.com/user-attachments/assets/ca5fb333-2e1a-48d6-a7ff-17e9328d5e1f)
This PR will fix this to use a proper label for this button.