### PR TITLE
fix: react router app directory bug

### DIFF
--- a/packages/create-app/src/create-app.ts
+++ b/packages/create-app/src/create-app.ts
@@ -53,7 +53,7 @@ export async function create(options: Options): Promise<void> {
       const relative = path.relative(path.join(dest, 'app'), file);
 
       if (!relative.startsWith(`..${path.sep}`)) {
-        return path.join(dest, 'src', relative);
+        return path.join(dest, 'app', relative);
       }
     }
 


### PR DESCRIPTION
I encountered an issue where I couldn’t run the project after creating React Router documentation. I quickly discovered that the project was set up with an src/ folder instead of an `app/` folder. This PR changes the `src/` value to resolve the issue and ensure the project runs correctly
Error
![image](https://github.com/user-attachments/assets/b9d61ca1-eec9-4fef-9709-f313b5a981ab)
![image](https://github.com/user-attachments/assets/9b37fe87-8871-41be-8ba2-1f540b91e958)
