### PR TITLE
Update route-tag.ts

### DIFF
--- a/examples/next-mdx/app/api/search/route-tag.ts
+++ b/examples/next-mdx/app/api/search/route-tag.ts
@@ -7,5 +7,5 @@ export const { GET } = createFromSource(source, (page) => ({
   url: page.url,
   id: page.url,
   structuredData: page.data.structuredData,
-  tag: '<value>',
+  tag: "<value>" // page.slugs[0]
 }));

--- a/examples/next-mdx/app/api/search/route-tag.ts
+++ b/examples/next-mdx/app/api/search/route-tag.ts
@@ -7,5 +7,6 @@ export const { GET } = createFromSource(source, (page) => ({
   url: page.url,
   id: page.url,
   structuredData: page.data.structuredData,
-  tag: "<value>" // page.slugs[0]
+  // use your desired value, like page.slugs[0]
+  tag: "<value>"
 }));


### PR DESCRIPTION
The existing "<value>" placeholder can be improved by adding a comment next to it that tells the likely way to get the tag, based on the slugs of the page.