### PR TITLE
fix(llms.txt): Await remark processor

### DIFF
--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -39,7 +39,7 @@ export async function GET() {
       cli: 'Fumadocs CLI (the CLI tool for automating Fumadocs apps)',
     }[dir ?? ''];
 
-    const processed = processor.process({
+    const processed = await processor.process({
       path: file,
       value: content,
     });


### PR DESCRIPTION
Currently the description at https://fumadocs.vercel.app/llms.txt is:
```
file: ./content/docs/cli/index.mdx
# Fumadocs CLI (the CLI tool for automating Fumadocs apps): User Guide

The CLI tool that automates setups and installing components.
        
[object Promise]

file: ./content/docs/headless/custom-source.mdx
# Fumadocs Core (core library of framework): Custom Source

Build your own content source
        
[object Promise]
```
because the promise for `processor.process` is not being awaited. This is a minor fix