### PR TITLE
OpenAPI: Add simple example to paramaters

### DIFF
--- a/packages/openapi/src/render/schema.tsx
+++ b/packages/openapi/src/render/schema.tsx
@@ -13,6 +13,7 @@ const keys: {
   minLength: 'Minimum length',
   maxLength: 'Maximum length',
   pattern: 'Pattern',
+  example: 'Example',
   format: 'Format',
 };
 


### PR DESCRIPTION
One liner to add the `example` key in the parameter docs.

Examples help understand how the parameters need to be, so they can be important to the documentation.