### PR TITLE
fix: enable TypeScript declaration generation for create-fumadocs-app

### DIFF
--- a/.changeset/heavy-trees-move.md
+++ b/.changeset/heavy-trees-move.md
@@ -1,0 +1,5 @@
+---
+'create-fumadocs-app': patch
+---
+
+Enable TypeScript declaration generation in tsup config

--- a/packages/create-app/tsup.config.ts
+++ b/packages/create-app/tsup.config.ts
@@ -1,10 +1,10 @@
 import { writeFileSync } from 'node:fs';
 import { defineConfig } from 'tsup';
-import corePkg from '../core/package.json';
-import uiPkg from '../ui/package.json';
-import mdxPkg from '../mdx/package.json';
-import mdxRemotePkg from '../mdx-remote/package.json';
 import contentCollectionsPkg from '../content-collections/package.json';
+import corePkg from '../core/package.json';
+import mdxRemotePkg from '../mdx-remote/package.json';
+import mdxPkg from '../mdx/package.json';
+import uiPkg from '../ui/package.json';
 
 const versions = {
   'fumadocs-core': corePkg.version,
@@ -25,4 +25,5 @@ export default defineConfig({
   entry: ['./src/index.ts', './src/create-app.ts'],
   format: 'esm',
   target: 'node18',
+  dts: true,
 });


### PR DESCRIPTION
- Updated the tsup configuration to generate declaration files with `dts: true`