### PR TITLE
fix: Link to layout page in header

### DIFF
--- a/apps/docs/app/layout.config.tsx
+++ b/apps/docs/app/layout.config.tsx
@@ -132,7 +132,7 @@ export const baseOptions: BaseLayoutProps = {
           icon: <Layout />,
           text: 'Layouts',
           description: 'See the available layouts of Fumadocs UI.',
-          url: '/docs/ui/blocks',
+          url: '/docs/ui/layouts/docs',
           menu: {
             className: 'lg:col-start-3',
           },


### PR DESCRIPTION
This PR fixes a broken link from the home page to the layouts page, which doesn't exist apparently