### PR TITLE
Updated the ThemeToggle button with hover:cursor-pointer

### DIFF
--- a/.changeset/sad-sites-admire.md
+++ b/.changeset/sad-sites-admire.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-ui': patch
+---
+
+Added a hover:cursor-pointer tailwind class to the ThemeToggle component.

--- a/packages/ui/src/components/layout/theme-toggle.tsx
+++ b/packages/ui/src/components/layout/theme-toggle.tsx
@@ -38,7 +38,7 @@ export function ThemeToggle({
   }, []);
 
   const container = cn(
-    'inline-flex items-center rounded-full border p-1',
+    'inline-flex items-center rounded-full border p-1 hover:cursor-pointer',
     className,
   );
 


### PR DESCRIPTION
I updated the `ToggleTheme` component to have a `hover:cursor-pointer` .

The reason the branch is called a bugfix, is because the button should have had this class (at least IMO, I'm ready to change this to either a feature or patch)

closes #1714