### PR TITLE
fix: DocsLayout import path

### DIFF
--- a/packages/cli/src/commands/customise.ts
+++ b/packages/cli/src/commands/customise.ts
@@ -90,7 +90,7 @@ export async function customise(resolver: Resolver, config: Config) {
         picocolors.dim('---'),
         'Open your `layout.tsx` files, replace the imports of components:',
         picocolors.greenBright(
-          '`fumadocs-ui/layouts/docs` -> `@/components/layouts/docs`',
+          '`fumadocs-ui/layouts/docs` -> `@/components/layouts/notebook`',
         ),
         pageAdded
           ? picocolors.greenBright(


### PR DESCRIPTION
When running the CLI for a custom DocsLayout, the generated files do not contain a page in the docs directory - i.e. `@/components/layouts/docs/shared.tsx` is the only option, which does not contains the DocsLayout. 

There is, however, an export from `@/components/layouts/notebook` for DocsLayout.

For reference:[ github.com/DeDevsClub/dedevs-docs/components/layouts](https://github.com/DeDevsClub/dedevs-docs/tree/main/components/layouts)