### PR TITLE
docs: fix incorrect escape character in code highlight examples

### DIFF
--- a/apps/docs/content/docs/ui/markdown.mdx
+++ b/apps/docs/content/docs/ui/markdown.mdx
@@ -237,15 +237,15 @@ We support some of the [Shiki Transformers](https://shiki.style/packages/transfo
 ````md
 ```tsx
 // highlight a line
-<div>Hello World</div>  // [\!code highlight]
+<div>Hello World</div>  // [!code highlight]
 
 // highlight a word
-// [\!code word:Fumadocs]
+// [!code word:Fumadocs]
 <div>Fumadocs</div>
 
 // diff styles
-console.log('hewwo'); // [\!code --]
-console.log('hello'); // [\!code ++]
+console.log('hewwo'); // [!code --]
+console.log('hello'); // [!code ++]
 ```
 ````
 


### PR DESCRIPTION
Removed unnecessary backslashes before `!code` annotations in the documentation examples. The incorrect escape prevented Shiki Transformers from recognizing highlight instructions properly.

[https://fumadocs.dev/docs/ui/markdown#shiki-transformers](https://fumadocs.dev/docs/ui/markdown#shiki-transformers)

![image](https://github.com/user-attachments/assets/528cda42-05a9-4d48-8b17-9196c3e4ef5f)
