### PR TITLE
fix(ui): scope Shiki classes to `fd-codeblock`

### DIFF
--- a/.changeset/grumpy-cows-beg.md
+++ b/.changeset/grumpy-cows-beg.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-ui': patch
+---
+
+fix(ui): scope Shiki classes to `fd-codeblock`

--- a/packages/ui/css/shiki.css
+++ b/packages/ui/css/shiki.css
@@ -1,8 +1,8 @@
-.shiki code span {
+.fd-codeblock .shiki code span {
   color: var(--shiki-light);
 }
 
-.dark .shiki code span {
+.dark .fd-codeblock .shiki code span {
   color: var(--shiki-dark);
 }
 
@@ -11,37 +11,37 @@
   font-size: 13px;
 }
 
-.shiki code .diff.remove {
+.fd-codeblock .shiki code .diff.remove {
   background-color: var(--fd-diff-remove-color);
   opacity: 0.7;
 }
 
-.shiki code .diff::before {
+.fd-codeblock .shiki code .diff::before {
   position: absolute;
   left: 6px;
 }
 
-.shiki code .diff.remove::before {
+.fd-codeblock .shiki code .diff.remove::before {
   content: '-';
   color: var(--fd-diff-remove-symbol-color);
 }
 
-.shiki code .diff.add {
+.fd-codeblock .shiki code .diff.add {
   background-color: var(--fd-diff-add-color);
 }
 
-.shiki code .diff.add::before {
+.fd-codeblock .shiki code .diff.add::before {
   content: '+';
   color: var(--fd-diff-add-symbol-color);
 }
 
-.shiki code .diff {
+.fd-codeblock .shiki code .diff {
   margin: 0 -16px;
   padding: 0 16px;
   position: relative;
 }
 
-.shiki .highlighted {
+.fd-codeblock .shiki .highlighted {
   margin: 0 -16px;
   padding: 0 16px;
   background-color: color-mix(
@@ -51,7 +51,7 @@
   );
 }
 
-.shiki .highlighted-word {
+.fd-codeblock .shiki .highlighted-word {
   padding: 1px 2px;
   margin: -1px -3px;
   border: 1px solid


### PR DESCRIPTION
I'm currently facing an issue in [Kibo UI](https://www.kibo-ui.com/) where my custom codeblock styles are being overwritten by the styles in Fumadocs `shiki.css`.

An easy way to solve for this is to scope all the Shiki classes to the existing `fd-codeblock` class.

Resolves https://github.com/haydenbleasel/kibo/issues/123
