### PR TITLE
Docs: Improve i18n link

### DIFF
--- a/examples/i18n/app/[lang]/(home)/page.tsx
+++ b/examples/i18n/app/[lang]/(home)/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { DynamicLink } from 'fumadocs-core/dynamic-link';
 
 export default function HomePage() {
   return (
@@ -22,15 +22,15 @@ export default function HomePage() {
       </h1>
       <p>
         You can open{' '}
-        <Link
-          href="/docs"
+        <DynamicLink
+          href="/[lang]/docs"
           style={{
             fontWeight: '600',
             textDecoration: 'underline',
           }}
         >
           /docs
-        </Link>{' '}
+        </DynamicLink>{' '}
         and see the documentation.
       </p>
     </main>

--- a/examples/i18n/app/layout.config.tsx
+++ b/examples/i18n/app/layout.config.tsx
@@ -6,13 +6,14 @@ export function baseOptions(locale: string): BaseLayoutProps {
     i18n,
     nav: {
       title: locale === 'cn' ? 'Chinese Docs' : 'English Docs',
+      url: `/${locale}`,
     },
     githubUrl: 'https://github.com',
     links: [
       {
         type: 'main',
         text: locale === 'cn' ? '文檔' : 'Documentation',
-        url: '/docs',
+        url: `/${locale}/docs`,
       },
     ],
   };


### PR DESCRIPTION
Fixes the jump links in i18n examples to make them more user-friendly. 

The changes include:

1. Improved navigation links.
2. Improved hero-to-documentation link.