### PR TITLE
Fix: fumadocs-python missing `griffe-typingdoc` dependency

### DIFF
--- a/.changeset/shaggy-actors-worry.md
+++ b/.changeset/shaggy-actors-worry.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-python": patch
+---
+
+Fix: Add missing dependency for `griffe_typingdoc`

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "griffe",
+    "griffe_typingdoc"
 ]
 
 [project.scripts]


### PR DESCRIPTION
```python
python $ uv run fumapy-generate pathlib
Traceback (most recent call last):
  File "/Users/stacia/Documents/GitHub/fumadocs/packages/python/.venv/bin/fumapy-generate", line 4, in <module>
    from fumapy import generate
  File "/Users/stacia/Documents/GitHub/fumadocs/packages/python/fumapy/__init__.py", line 6, in <module>
    from griffe_typingdoc import TypingDocExtension
ModuleNotFoundError: No module named 'griffe_typingdoc'
```

https://github.com/fuma-nama/fumadocs/blob/3372792d4755113f6f2e5316b71593fa0f8d7b4e/packages/python/fumapy/__init__.py#L6