### PR TITLE
feat(ui): add hex color support to Banner component

### DIFF
--- a/packages/ui/src/components/banner.tsx
+++ b/packages/ui/src/components/banner.tsx
@@ -4,6 +4,53 @@ import { type HTMLAttributes, useEffect, useState } from 'react';
 import { X } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { buttonVariants } from '@/components/ui/button';
+import { hexToRGBA } from '@/theme/typography/styles';
+
+type BannerVariant = 'rainbow' | 'normal' | `#${string}`;
+
+function generateHexLayers(hexColor: string) {
+  const firstLayer = {
+    maskImage,
+    maskComposite: 'intersect',
+    animation: 'fd-moving-banner 16s linear infinite',
+    '--start': hexToRGBA(hexColor, 0.5),
+    '--mid': hexToRGBA(hexColor, 0.77),
+    '--end': hexToRGBA(hexColor, 0.4),
+    '--via': hexToRGBA(hexColor, 0.4),
+    animationDirection: 'reverse',
+    backgroundImage:
+      'repeating-linear-gradient(60deg, var(--end), var(--start) 2%, var(--start) 5%, transparent 8%, transparent 14%, var(--via) 18%, var(--via) 22%, var(--mid) 28%, var(--mid) 30%, var(--via) 34%, var(--via) 36%, transparent, var(--end) calc(50% - 12px))',
+    backgroundSize: '200% 100%',
+    mixBlendMode: 'difference',
+  } as const;
+
+  const secondLayer = {
+    maskImage,
+    maskComposite: 'intersect',
+    animation: 'fd-moving-banner 20s linear infinite',
+    '--start': hexToRGBA(hexColor, 0.5),
+    '--mid': hexToRGBA(hexColor, 0.4),
+    '--end': hexToRGBA(hexColor, 0.51),
+    '--via': hexToRGBA(hexColor, 0.56),
+    backgroundImage:
+      'repeating-linear-gradient(45deg, var(--end), var(--start) 4%, var(--start) 8%, transparent 9%, transparent 14%, var(--mid) 16%, var(--mid) 20%, transparent, var(--via) 36%, var(--via) 40%, transparent 42%, var(--end) 46%, var(--end) calc(50% - 16.8px))',
+    backgroundSize: '200% 100%',
+    mixBlendMode: 'color-dodge',
+  } as const;
+
+  return (
+    <>
+      <div className="absolute inset-0 z-[-1]" style={firstLayer} />
+      <div className="absolute inset-0 z-[-1]" style={secondLayer} />
+      <style>
+        {`@keyframes fd-moving-banner {
+          from { background-position: 0% 0;  }
+          to { background-position: 100% 0;  }
+        }`}
+      </style>
+    </>
+  );
+}
 
 export function Banner({
   id,
@@ -20,7 +67,7 @@ export function Banner({
   /**
    * @defaultValue 'normal'
    */
-  variant?: 'rainbow' | 'normal';
+  variant?: BannerVariant;
 
   /**
    * Change Fumadocs layout styles
@@ -38,13 +85,16 @@ export function Banner({
 
   if (!open) return null;
 
+  const isHexColor = typeof variant === 'string' && variant.startsWith('#');
+
   return (
     <div
       id={id}
       {...props}
       className={cn(
-        'sticky top-0 z-40 flex flex-row items-center justify-center bg-fd-secondary px-4 text-center text-sm font-medium',
-        variant === 'rainbow' && 'bg-fd-background',
+        'sticky top-0 z-40 flex flex-row items-center justify-center px-4 text-center text-sm font-medium',
+        variant === 'normal' && 'bg-fd-secondary',
+        (variant === 'rainbow' || isHexColor) && 'bg-fd-background',
         !open && 'hidden',
         props.className,
       )}
@@ -71,6 +121,7 @@ export function Banner({
       ) : null}
 
       {variant === 'rainbow' ? rainbowLayer : null}
+      {isHexColor ? generateHexLayers(variant) : null}
       {props.children}
       {id ? (
         <button

--- a/packages/ui/src/theme/typography/styles.ts
+++ b/packages/ui/src/theme/typography/styles.ts
@@ -13,6 +13,13 @@ function em(px: number, base: number) {
   return `${round(px / base)}em`;
 }
 
+export function hexToRGBA(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
 const colors = {
   '--tw-prose-body':
     'color-mix(in oklab, var(--color-fd-foreground) 90%, transparent)',


### PR DESCRIPTION

### Add hex color variant to Banner component

this PR extends `Banner` to support custom hex color gradients while maintaining the existing variants (normal and rainbow)

### Example
```tsx
<Banner variant="#ff6900">
    Build excellent documentation site with less effort —{" "}
    <span className="underline">Learn more</span>
</Banner>
```

### Changes
- Add hex color support as a new banner variant type
- Implement animated gradient layers using the provided hex color
- Keep existing functionality intact (normal and rainbow variants)

https://github.com/user-attachments/assets/ced87f6e-236a-47fa-b9fe-7e9d0e9b1328

