### PR TITLE
OpenAPI: Fix non-undefined values not rendering

### DIFF
--- a/packages/openapi/src/render/schema.tsx
+++ b/packages/openapi/src/render/schema.tsx
@@ -126,7 +126,7 @@ export function Schema({
       value: string;
     }[] = [];
 
-    if (schema.default) {
+    if (schema.default !== undefined) {
       fields.push({
         key: 'Default',
         value: JSON.stringify(schema.default),
@@ -402,16 +402,16 @@ function getRange(
   exclusiveMax: number | undefined,
 ) {
   const out = [];
-  if (min) {
+  if (min !== undefined) {
     out.push(`${min} <=`);
-  } else if (exclusiveMin) {
+  } else if (exclusiveMin !== undefined) {
     out.push(`${exclusiveMin} <`);
   }
 
   out.push(value);
-  if (max) {
+  if (max !== undefined) {
     out.push(`<= ${max}`);
-  } else if (exclusiveMax) {
+  } else if (exclusiveMax !== undefined) {
     out.push(`< ${exclusiveMax}`);
   }
   if (out.length > 1) return out.join(' ');


### PR DESCRIPTION
On OpenAPI references the current ifs ignores _zero_ on ranges and _false_, _null_ or _zero_ in default values. So they don't show up on the interface. I just forced a check on undefined.