### PR TITLE
fix(docslayout): remove sidebar layout space when sidebar is disabled

### DIFF
--- a/.changeset/mean-signs-smile.md
+++ b/.changeset/mean-signs-smile.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-ui': patch
+---
+
+Fix layout: remove reserved sidebar space when sidebar is disabled in DocsLayout

--- a/packages/ui/src/layouts/docs.tsx
+++ b/packages/ui/src/layouts/docs.tsx
@@ -79,7 +79,9 @@ export function DocsLayout({
   const links = getLinks(props.links ?? [], props.githubUrl);
 
   const variables = cn(
-    'md:[--fd-sidebar-width:268px] lg:[--fd-sidebar-width:286px] xl:[--fd-toc-width:286px]',
+    sidebarEnabled &&
+      'md:[--fd-sidebar-width:268px] lg:[--fd-sidebar-width:286px]',
+    'xl:[--fd-toc-width:286px]',
     !nav.component && nav.enabled !== false
       ? '[--fd-nav-height:56px] md:[--fd-nav-height:0px]'
       : undefined,


### PR DESCRIPTION
### Problem
When `sidebar.enabled = false` in `DocsLayout`, the layout still reserves space for the sidebar, causing visual imbalance and wasted space.

### Solution
- Conditional layout rendering now removes sidebar space when it's disabled.
- Main content correctly takes full width in the absence of a sidebar.

### Related
- Fixes: #2066 