### PR TITLE
fix(toc): apply consistent hover color using `hover:text-fd-foreground`

### DIFF
--- a/packages/ui/src/components/layout/toc-clerk.tsx
+++ b/packages/ui/src/components/layout/toc-clerk.tsx
@@ -145,7 +145,7 @@ function TOCItem({
       style={{
         paddingInlineStart: getItemOffset(item.depth),
       }}
-      className="prose relative py-1.5 text-sm text-fd-muted-foreground hover:text-fd-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-fd-primary"
+      className="prose relative py-1.5 text-sm text-fd-muted-foreground hover:text-fd-accent-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-fd-primary"
     >
       {offset !== upperOffset ? (
         <svg

--- a/packages/ui/src/components/layout/toc-clerk.tsx
+++ b/packages/ui/src/components/layout/toc-clerk.tsx
@@ -145,7 +145,7 @@ function TOCItem({
       style={{
         paddingInlineStart: getItemOffset(item.depth),
       }}
-      className="prose relative py-1.5 text-sm text-fd-muted-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-fd-primary"
+      className="prose relative py-1.5 text-sm text-fd-muted-foreground hover:text-fd-foreground transition-colors [overflow-wrap:anywhere] first:pt-0 last:pb-0 data-[active=true]:text-fd-primary"
     >
       {offset !== upperOffset ? (
         <svg


### PR DESCRIPTION
Updates the Table of Contents links to use `hover:text-fd-foreground` for hover states. This ensures visual consistency with the design system's foreground color, improving readability and user experience during interaction.