### PR TITLE
Fix Vite and Tanstack Router configuration warnings

### DIFF
--- a/.changeset/upset-yaks-fry.md
+++ b/.changeset/upset-yaks-fry.md
@@ -1,0 +1,5 @@
+---
+"create-fumadocs-app": minor
+---
+
+Fix Vite and Tanstack Router configuration warnings

--- a/packages/create-app/template/tanstack-start/package.json
+++ b/packages/create-app/template/tanstack-start/package.json
@@ -9,26 +9,27 @@
   },
   "dependencies": {
     "@fumadocs/mdx-remote": "workspace:*",
-    "@tanstack/react-router": "^1.127.8",
-    "@tanstack/react-router-devtools": "^1.127.8",
-    "@tanstack/react-start": "^1.127.8",
+    "@tanstack/react-router": "^1.128.0",
+    "@tanstack/react-router-devtools": "^1.128.0",
+    "@tanstack/react-start": "^1.128.1",
     "fumadocs-core": "workspace:*",
     "fumadocs-ui": "workspace:*",
     "gray-matter": "^4.0.3",
     "lucide-static": "^0.525.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "tailwind-merge": "^3.3.1",
-    "vite": "^7.0.4",
+    "vite": "^7.0.5",
     "zod": "^4.0.5"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.11",
-    "@types/node": "^24.0.13",
-    "@types/react": "^19.0.8",
-    "@types/react-dom": "^19.0.3",
+    "@types/node": "^24.0.14",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.6.0",
     "tailwindcss": "^4.1.11",
-    "typescript": "^5.7.2",
+    "typescript": "^5.8.3",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/packages/create-app/template/tanstack-start/src/components/NotFound.tsx
+++ b/packages/create-app/template/tanstack-start/src/components/NotFound.tsx
@@ -1,0 +1,13 @@
+export function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold">404</h1>
+        <p className="mt-4 text-lg">Page not found</p>
+        <a href="/" className="mt-6 inline-block text-blue-600 hover:underline">
+          Go back home
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/packages/create-app/template/tanstack-start/src/components/NotFound.tsx
+++ b/packages/create-app/template/tanstack-start/src/components/NotFound.tsx
@@ -1,13 +1,28 @@
+import { Link } from '@tanstack/react-router';
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+
 export function NotFound() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold">404</h1>
-        <p className="mt-4 text-lg">Page not found</p>
-        <a href="/" className="mt-6 inline-block text-blue-600 hover:underline">
-          Go back home
-        </a>
+    <HomeLayout
+      nav={{
+        title: 'Tanstack Start',
+      }}
+      className="text-center py-32 justify-center"
+    >
+      <div className="flex flex-col items-center gap-4">
+        <h1 className="text-6xl font-bold text-fd-muted-foreground">404</h1>
+        <h2 className="text-2xl font-semibold">Page Not Found</h2>
+        <p className="text-fd-muted-foreground max-w-md">
+          The page you are looking for might have been removed, had its name changed,
+          or is temporarily unavailable.
+        </p>
+        <Link
+          to="/"
+          className="mt-4 px-4 py-2 rounded-lg bg-fd-primary text-fd-primary-foreground font-medium text-sm hover:opacity-90 transition-opacity"
+        >
+          Back to Home
+        </Link>
       </div>
-    </div>
+    </HomeLayout>
   );
 }

--- a/packages/create-app/template/tanstack-start/src/router.tsx
+++ b/packages/create-app/template/tanstack-start/src/router.tsx
@@ -1,11 +1,13 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
+import { NotFound } from './components/NotFound';
 
 export function createRouter() {
   return createTanStackRouter({
     routeTree,
     defaultPreload: 'intent',
     scrollRestoration: true,
+    defaultNotFoundComponent: NotFound,
   });
 }
 

--- a/packages/create-app/template/tanstack-start/vite.config.ts
+++ b/packages/create-app/template/tanstack-start/vite.config.ts
@@ -2,6 +2,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import { defineConfig } from 'vite';
 import tsConfigPaths from 'vite-tsconfig-paths';
 import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   server: {
@@ -12,6 +13,12 @@ export default defineConfig({
     tsConfigPaths({
       projects: ['./tsconfig.json'],
     }),
-    tanstackStart(),
+    tanstackStart({
+      customViteReactPlugin: true,
+    }),
+    react(),
   ],
+  optimizeDeps: {
+    exclude: ['search-default'],
+  },
 });

--- a/packages/create-app/template/tanstack-start/vite.config.ts
+++ b/packages/create-app/template/tanstack-start/vite.config.ts
@@ -18,7 +18,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  optimizeDeps: {
-    exclude: ['search-default'],
-  },
 });


### PR DESCRIPTION
- [x] Adds `vite-react` plugin with required `customViteReactPlugin: true` flag 
- [x] Configures custom `NotFound` component for TanStack Router 
- [x] Updates dependencies to latest versions 

_Issues Resolved:_ 
1. TanStack Start vite-react plugin warning 
2. Missing custom 404 component warning 
3. Module resolution errors during navigation 
4. React hydration errors (useMemo null reference) 

--

_Before:_

<img width="3680" height="2724" alt="test-fuma" src="https://github.com/user-attachments/assets/8f1cd6b5-c57d-4246-bf7e-78e128033778" />

_After:_

<img width="3680" height="2004" alt="fuma-test-after" src="https://github.com/user-attachments/assets/bdb81f67-1e82-46af-9085-2db8f47d15ef" />

_Demo:_

![fuma-tanstack-demo](https://github.com/user-attachments/assets/3f8b62dc-e8e5-4886-a303-6b6680277c46)

> [!NOTE]  
> _This demo demonstrates the hydration errors and module resolution failures causing error flashes during client-side navigation._