### PR TITLE
Add `Content-Type` header & `method` option to OpenAPI JavaScript code example

### DIFF
--- a/.changeset/short-candies-greet.md
+++ b/.changeset/short-candies-greet.md
@@ -1,5 +1,5 @@
 ---
-'fumadocs-openapi': minor
+'fumadocs-openapi': patch
 ---
 
 Add method option and Content-Type header to generated JavaScript code examples

--- a/.changeset/short-candies-greet.md
+++ b/.changeset/short-candies-greet.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-openapi': minor
+---
+
+Add method option and Content-Type header to generated JavaScript code examples

--- a/packages/openapi/src/requests/javascript.ts
+++ b/packages/openapi/src/requests/javascript.ts
@@ -6,6 +6,11 @@ export const generator: SampleGenerator = (url, data, { mediaAdapters }) => {
   const options = new Map<string, string>();
   const headers: Record<string, string> = {};
 
+  options.set('method', JSON.stringify(data.method));
+  if (data.bodyMediaType) {
+    headers['Content-Type'] = data.bodyMediaType;
+  }
+
   for (const [k, v] of Object.entries(data.header)) {
     headers[k] = v.value as string;
   }

--- a/packages/openapi/test/out/samples/1.js
+++ b/packages/openapi/test/out/samples/1.js
@@ -3,7 +3,9 @@ const body = JSON.stringify({
 })
 
 fetch("http://localhost:8080/hello_world?search=ai", {
+  method: "GET",
   headers: {
+    "Content-Type": "application/json",
     "authorization": "Bearer",
     "cookie": "mode=light"
   },


### PR DESCRIPTION
Currently JS code examples generated by the OpenAPI integration lack the `method` option and the `Content-Type` header inside the `fetch`.

This PR adds them. What would previously be: 
```js
const body = JSON.stringify({
  "name": "Marc",
  "email": "marc@scalar.com",
  "password": "i-love-scalar"
})

fetch("https://galaxy.scalar.com/user/signup", {
  body
})
```

Is now: 
```js
const body = JSON.stringify({
  "name": "Marc",
  "email": "marc@scalar.com",
  "password": "i-love-scalar"
})

fetch("https://galaxy.scalar.com/user/signup", {
  method: "POST",
  headers: {
    "Content-Type": "application/json"
  },
  body
})
```