### PR TITLE
fix: ignore IME composition to avoid accidental selection

### DIFF
--- a/.changeset/loud-apples-stay.md
+++ b/.changeset/loud-apples-stay.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-ui': patch
+---
+
+Ignore IME composition to avoid accidental selection

--- a/packages/ui/src/components/dialog/search.tsx
+++ b/packages/ui/src/components/dialog/search.tsx
@@ -227,7 +227,7 @@ export function SearchDialogList({
   };
 
   const onKey = useEffectEvent((e: KeyboardEvent) => {
-    if (!items) return;
+    if (!items || e.isComposing) return;
 
     if (e.key === 'ArrowDown' || e.key == 'ArrowUp') {
       let idx = items.findIndex((item) => item.id === active);


### PR DESCRIPTION
When using CJK IMEs, text stays in a composition state until it is committed.

Typical IME keys:

- <kbd>Enter</kbd>: commits the current composition
- <kbd>↑</kbd> / <kbd>↓</kbd>: cycles through candidate words

Because the search dialog listens for these same keys, it may:

- open the first result when the user presses <kbd>Enter</kbd> to commit text
- jump the highlight when the user <kbd>↑</kbd> / <kbd>↓</kbd> to pick a candidate

This PR guards the keydown handler with [isComposing](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing), so IME composition keys are ignored and the dialog no longer hijacks them.
