### PR TITLE
fix(docs): update broken /tanstack-start link to /tanstack

### DIFF
--- a/apps/docs/content/docs/mdx/index.mdx
+++ b/apps/docs/content/docs/mdx/index.mdx
@@ -15,7 +15,7 @@ Get started with Fumadocs MDX:
   <Card title="React Router" href="/docs/mdx/vite/react-router">
     Using Fumadocs MDX with React Router 7 or above.
   </Card>
-  <Card title="Tanstack Start" href="/docs/mdx/vite/tanstack-start">
+  <Card title="Tanstack Start" href="/docs/mdx/vite/tanstack">
     Using Fumadocs MDX with Tanstack Start/Router.
   </Card>
 </Cards>


### PR DESCRIPTION
Update invalid `/tanstack-start` link to `/tanstack` in docs card