### PR TITLE
📚️ docs(headless/custom-source/examples): add payload cms

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -605,7 +605,7 @@ function Features() {
               target="_blank"
               className={cn(buttonVariants({ variant: 'outline' }))}
             >
-              BaseHub CMS example
+              BaseHub CMS
             </a>
             <a
               href="https://github.com/fuma-nama/fumadocs-sanity"
@@ -613,7 +613,15 @@ function Features() {
               target="_blank"
               className={cn(buttonVariants({ variant: 'ghost' }))}
             >
-              Sanity example
+              Sanity
+            </a>
+            <a
+              href="https://github.com/MFarabi619/fumadocs-payloadcms"
+              rel="noreferrer noopener"
+              target="_blank"
+              className={cn(buttonVariants({ variant: 'ghost' }))}
+            >
+              Payload CMS
             </a>
           </div>
           <Image

--- a/apps/docs/content/docs/headless/custom-source.mdx
+++ b/apps/docs/content/docs/headless/custom-source.mdx
@@ -15,6 +15,7 @@ You can see examples to use Fumadocs with a CMS, which allows a nice experience 
 
 - [BaseHub](https://github.com/fuma-nama/fumadocs-basehub)
 - [Sanity](https://github.com/fuma-nama/fumadocs-sanity)
+- [Payload CMS](https://github.com/MFarabi619/fumadocs-payloadcms)
 
 For a custom content source implementation, you will need:
 


### PR DESCRIPTION
Closes #2053.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md).
- [x] I've rebased my branch onto `dev` **before** creating this PR.
- [x] I've checked for similar PRs **before** creating this PR.
- [x] I've formatted my code with `pnpm run prettier`.
- [ ] I've added changesets with `pnpm changeset`.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [ ] I've added tests to cover my changes (if applicable).
- [x] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes and ran `pnpm test`.
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly.

## Screenshots

| Before | After |
|-|-|
| <img width="640" height="713" alt="image" src="https://github.com/user-attachments/assets/1ea440f8-c8ee-4df7-9d4e-069c43e19fa7" /> | <img width="619" height="702" alt="image" src="https://github.com/user-attachments/assets/145382c0-fc8c-404b-8993-716955a18d6a" /> |
| <img width="193" height="232" alt="image" src="https://github.com/user-attachments/assets/d30dcaad-013e-4909-83d8-c5da7dc97aac" /> | <img width="176" height="268" alt="image" src="https://github.com/user-attachments/assets/cd210259-aabe-466f-b72f-2dea9566507e" /> |

### 👋 Key Notes

- Kept the template as clean and minimal as possible
- Used SQLite instead of PostgreSQL or MongoDB to lower the learning curve for beginners & save them from the headache of having to set up a database
- Kept the README language as similar to [Fumadocs Sanity](https://github.com/fuma-nama/fumadocs-sanity) as possible
- Included a `vercel.json` & `netlify.toml` to make the template as deploy-ready as possible.

| [GitHub Repo](https://github.com/MFarabi619/fumadocs-payloadcms) | [Deployment](https://fumadocs-payloadcms.vercel.app) |
|-|-|
| <img width="1008" height="1008" alt="image" src="https://github.com/user-attachments/assets/0bc3f721-d6d7-465c-83b1-ab5077fb76d9" /> | <img width="2545" height="1512" alt="image" src="https://github.com/user-attachments/assets/e70cd0c4-756f-489f-b879-e26710aaf2de" /> |
| <img width="984" height="1296" alt="image" src="https://github.com/user-attachments/assets/abc3b271-edf7-40c4-b5d7-0ec826374c8c" /> | <img width="2544" height="1510" alt="image" src="https://github.com/user-attachments/assets/4f867cc7-fbdc-4e10-9938-55994707502f" /> |

### 🏗️ TODO

- [x] Provide steps on setting up Turso
- [x] Repair broken admin panel due to unseeded production database

### ✨ Nice-to-have
- [ ] Provide PostgreSQL option
- [ ] Provide MongoDB option
- [ ] Provide Nix option
- [ ] Provide [FumaDB](https://fumadb.vercel.app) option
- [ ] Provide OAuth scaffolding
- [ ] Provide email scaffolding
- [x] Provide seed script
- [x] Provide codesandbox link 
- [ ] Pair with a kitchen-sink Payload CMS template such as [Shopnex](https://github.com/shopnex-ai/shopnex) and/or [Quantum Leap](https://github.com/akhrarovsaid/payload-theme-quantum-leap?tab=readme-ov-file)

---

- Configured live preview both for dev & prod.
- Provided a very nice and simple seed script that detects an empty database when the admin user is missing, automatically creates it with media uploads and wiring up the relations; saving a lot of development hassle.
- Made the env vars default to blank values for local dev, so people can quickly clone and try the entire app without having any `.env` at all.
- Pre-filled the login form only for dev environments, greatly improving developer experience.
- Ordered env vars in `payload.config.ts` such that the local dev environment setup can very easily be overridden for quick & easy migrations/experimentation against staging environments.

| | | |
|-|-|-|
| <img width="1265" height="500" alt="image" src="https://github.com/user-attachments/assets/6ed15cef-d09d-400a-b7b1-c56cb7ea0dbb" /> | <img width="1275" height="729" alt="image" src="https://github.com/user-attachments/assets/a1f7eedc-44af-4ea4-80cf-1ac121bd80be" /> | <img width="659" height="456" alt="image" src="https://github.com/user-attachments/assets/c66b8434-bf93-404e-92f1-7f8e0b72a2b9" /> |

- Ruled the rest of the features out of scope for this PR as they greatly add to the maintenance burden of the example, and also make it less beginner-friendly due to system-level configs. The setup also works without the email plugin, and left that out as well to save on another env var config.
