### PR TITLE
fix: ensure metadata points to production url

### DIFF
--- a/apps/docs/lib/metadata.ts
+++ b/apps/docs/lib/metadata.ts
@@ -34,6 +34,6 @@ export function createMetadata(override: Metadata): Metadata {
 }
 
 export const baseUrl =
-  process.env.NODE_ENV === 'development' || !process.env.VERCEL_URL
+  process.env.NODE_ENV === 'development' || !process.env.VERCEL_PROJECT_PRODUCTION_URL
     ? new URL('http://localhost:3000')
-    : new URL(`https://${process.env.VERCEL_URL}`);
+    : new URL(`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`);


### PR DESCRIPTION
This change ensures that links point to the right url on production env. e.g. if you look at the sitemap.xml file you can see that all urls in it are incorrectly pointed to the temporary vercel deployment url: https://fumadocs.dev/sitemap.xml This will make the sitemap be pointed to the right url fumadocs.dev and in turn help google discover the website content.