### PR TITLE
docs: static export instruction clarified

### DIFF
--- a/apps/docs/content/docs/ui/static-export.mdx
+++ b/apps/docs/content/docs/ui/static-export.mdx
@@ -28,11 +28,10 @@ See [Next.js docs](https://nextjs.org/docs/app/guides/static-exports) for limita
 
 ### Built-in Search
 
-Learn how to 
-- [enable static mode](/docs/ui/search/orama#static) on search client.
-- [enable static indexing](/docs/headless/search/orama#static-export) on search endpoint.
+You will need extra configurations to statically store the search indexes, and search will be computed on browser instead:
 
-This enables the route handler to be statically cached and search will be computed on browser instead.
+1. **Search Client:** [enable static mode](/docs/ui/search/orama#static).
+2. **Search Server:** [output static indexes](/docs/headless/search/orama#static-export).
 
 ### Cloud Solutions
 


### PR DESCRIPTION
Built-in search implementation for static export was not working as expected due to missing 'indexing' step. Which was documented but not linked properly in the static export documentation.

Also, in cloud solution, there aren't any important details, so "Built-in" implementation details are provided just below the `nextjs` config. & cloud section is moved below.