### PR TITLE
✨ feat(ui): Add tooltip support for theme toggle component

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
     "build:pre": "tsx ./scripts/pre-build.mts",
     "build:post": "tsx ./scripts/post-build.mts",
     "clean": "rimraf .next",
-    "dev": "next dev --turbo",
+    "dev": "next dev --turbopack",
     "lint": "fumadocs-mdx && tsx ./scripts/lint.mts && eslint .",
     "start": "next start"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -92,6 +92,7 @@
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/react-tooltip": "^1.2.7",
     "class-variance-authority": "^0.7.1",
     "fumadocs-core": "workspace:*",
     "lodash.merge": "^4.6.2",

--- a/packages/ui/src/components/layout/theme-toggle.tsx
+++ b/packages/ui/src/components/layout/theme-toggle.tsx
@@ -4,6 +4,7 @@ import { Moon, Sun, Airplay } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { type HTMLAttributes, useLayoutEffect, useState } from 'react';
 import { cn } from '@/utils/cn';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 
 const itemVariants = cva(
   'size-6.5 rounded-full p-1.5 text-fd-muted-foreground',
@@ -26,9 +27,11 @@ const full = [
 export function ThemeToggle({
   className,
   mode = 'light-dark',
+  tooltip = false,
   ...props
 }: HTMLAttributes<HTMLElement> & {
   mode?: 'light-dark' | 'light-dark-system';
+  tooltip?: boolean;
 }) {
   const { setTheme, theme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -50,11 +53,27 @@ export function ThemeToggle({
         className={container}
         aria-label={`Toggle Theme`}
         onClick={() => setTheme(value === 'light' ? 'dark' : 'light')}
-        data-theme-toggle=""
+        data-theme-toggle
         {...props}
       >
         {full.map(([key, Icon]) => {
           if (key === 'system') return;
+
+          if (tooltip) {
+            return (
+              <Tooltip key={key}>
+                <TooltipTrigger asChild>
+                  <Icon
+                    fill="currentColor"
+                    className={cn(itemVariants({ active: value === key }))}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  {key.charAt(0).toUpperCase() + key.slice(1)} Mode
+                </TooltipContent>
+              </Tooltip>
+            );
+          }
 
           return (
             <Icon
@@ -71,17 +90,35 @@ export function ThemeToggle({
   const value = mounted ? theme : null;
 
   return (
-    <div className={container} data-theme-toggle="" {...props}>
-      {full.map(([key, Icon]) => (
-        <button
-          key={key}
-          aria-label={key}
-          className={cn(itemVariants({ active: value === key }))}
-          onClick={() => setTheme(key)}
-        >
-          <Icon className="size-full" fill="currentColor" />
-        </button>
-      ))}
+    <div className={container} data-theme-toggle {...props}>
+      {full.map(([key, Icon]) => {
+        if (tooltip) {
+          return (
+            <Tooltip key={key}>
+              <TooltipTrigger asChild>
+                <Icon
+                  fill="currentColor"
+                  className={cn(itemVariants({ active: value === key }))}
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                {key.charAt(0).toUpperCase() + key.slice(1)} Mode
+              </TooltipContent>
+            </Tooltip>
+          );
+        }
+
+        return (
+          <button
+            key={key}
+            aria-label={key}
+            className={cn(itemVariants({ active: value === key }))}
+            onClick={() => setTheme(key)}
+          >
+            <Icon className="size-full" fill="currentColor" />
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -1,0 +1,52 @@
+'use client';
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { cn } from '@/utils/cn';
+
+function TooltipProvider({
+  delayDuration = 2,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return <TooltipPrimitive.Provider delayDuration={delayDuration} {...props} />;
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        sideOffset={sideOffset}
+        className={cn(
+          'animate-in bg-fd-foreground text-fd-primary-foreground fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-sm text-balance',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-fd-foreground fill-fd-foreground z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/packages/ui/src/layouts/docs.tsx
+++ b/packages/ui/src/layouts/docs.tsx
@@ -70,7 +70,7 @@ export function DocsLayout({
   } = {},
   searchToggle = {},
   disableThemeSwitch = false,
-  themeSwitch = { enabled: !disableThemeSwitch },
+  themeSwitch = { enabled: !disableThemeSwitch, tooltip: false },
   i18n = false,
   children,
   ...props
@@ -145,7 +145,11 @@ export function DocsLayout({
             ) : null}
             {themeSwitch.enabled !== false &&
               (themeSwitch.component ?? (
-                <ThemeToggle className="p-0 ms-1.5" mode={themeSwitch.mode} />
+                <ThemeToggle
+                  className="p-0 ms-1.5"
+                  mode={themeSwitch.mode}
+                  tooltip={themeSwitch.tooltip}
+                />
               ))}
             <SidebarTrigger
               className={cn(
@@ -223,7 +227,11 @@ export function DocsLayout({
             ) : null}
             {themeSwitch.enabled !== false &&
               (themeSwitch.component ?? (
-                <ThemeToggle className="p-0 ms-1.5" mode={themeSwitch.mode} />
+                <ThemeToggle
+                  className="p-0 ms-1.5"
+                  mode={themeSwitch.mode}
+                  tooltip={themeSwitch.tooltip}
+                />
               ))}
           </div>
           {footer}

--- a/packages/ui/src/layouts/home.tsx
+++ b/packages/ui/src/layouts/home.tsx
@@ -50,7 +50,7 @@ export function HomeLayout(
     githubUrl,
     i18n,
     disableThemeSwitch = false,
-    themeSwitch = { enabled: !disableThemeSwitch },
+    themeSwitch = { enabled: !disableThemeSwitch, tooltip: false },
     searchToggle,
     ...rest
   } = props;
@@ -131,7 +131,11 @@ export function Header({
         )}
         {themeSwitch.enabled !== false &&
           (themeSwitch.component ?? (
-            <ThemeToggle className="max-lg:hidden" mode={themeSwitch?.mode} />
+            <ThemeToggle
+              className="max-lg:hidden"
+              mode={themeSwitch?.mode}
+              tooltip={themeSwitch.tooltip}
+            />
           ))}
         {i18n ? (
           <LanguageToggle className="max-lg:hidden">
@@ -177,7 +181,10 @@ export function Header({
               ) : null}
               {themeSwitch.enabled !== false &&
                 (themeSwitch.component ?? (
-                  <ThemeToggle mode={themeSwitch?.mode} />
+                  <ThemeToggle
+                    mode={themeSwitch?.mode}
+                    tooltip={themeSwitch.tooltip}
+                  />
                 ))}
             </div>
           </MenuContent>

--- a/packages/ui/src/layouts/notebook.tsx
+++ b/packages/ui/src/layouts/notebook.tsx
@@ -74,7 +74,7 @@ export function DocsLayout(props: DocsLayoutProps) {
     sidebar: { tabs: tabOptions, ...sidebarProps } = {},
     i18n = false,
     disableThemeSwitch = false,
-    themeSwitch = { enabled: !disableThemeSwitch },
+    themeSwitch = { enabled: !disableThemeSwitch, tooltip: false },
   } = props;
 
   const navMode = nav.mode ?? 'auto';
@@ -240,7 +240,10 @@ export function DocsLayout(props: DocsLayoutProps) {
           ) : null}
           {themeSwitch.enabled !== false &&
             (themeSwitch.component ?? (
-              <ThemeToggle mode={themeSwitch.mode ?? 'light-dark-system'} />
+              <ThemeToggle
+                mode={themeSwitch.mode ?? 'light-dark-system'}
+                tooltip={themeSwitch.tooltip}
+              />
             ))}
           {footer}
         </HideIfEmpty>
@@ -394,6 +397,7 @@ function DocsNavbar({
               <ThemeToggle
                 className="ms-2 max-md:hidden"
                 mode={themeSwitch.mode ?? 'light-dark-system'}
+                tooltip={themeSwitch.tooltip}
               />
             ))}
           {sidebarCollapsible && navMode === 'top' ? (

--- a/packages/ui/src/layouts/shared.tsx
+++ b/packages/ui/src/layouts/shared.tsx
@@ -22,6 +22,7 @@ export interface BaseLayoutProps {
   themeSwitch?: {
     enabled?: boolean;
     component?: ReactNode;
+    tooltip?: boolean;
     mode?: 'light-dark' | 'light-dark-system';
   };
 


### PR DESCRIPTION
🔧 Enhanced theme toggle functionality:
- Added `@radix-ui/react-tooltip` dependency for robust tooltip implementation
- Created reusable Tooltip component with custom styling and animations
- Extended ThemeToggle component with optional tooltip prop 
- Updated all layout components (docs, home, notebook) to support tooltip configuration 
- Improved accessibility with hover hints showing "Light Mode", "Dark Mode", and "System Mode"

🎨 UX improvements:
- Users can now see helpful tooltips when hovering over theme toggle icons
- Maintains backward compatibility with existing implementations 
- Configurable tooltip behavior via layout props

🛠️ Technical changes:
- Fixed dev script to use --turbopack flag (was --turbo)
-  Added TypeScript interfaces for tooltip configuration
- Consistent tooltip styling across all layouts