### PR TITLE
fix(template+next+fuma): docs page metadata return type

### DIFF
--- a/packages/create-app/template/+next+fuma-docs-mdx/app/docs/[[...slug]]/page.tsx
+++ b/packages/create-app/template/+next+fuma-docs-mdx/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import {
   DocsDescription,
   DocsTitle,
 } from 'fumadocs-ui/page';
+import { Metadata } from "next";
 import { notFound } from 'next/navigation';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { getMDXComponents } from '@/mdx-components';
@@ -40,7 +41,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
-}) {
+}): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();


### PR DESCRIPTION
Fixes:
TS71008: The Next.js "generateMetadata" export should have a return type of "Promise<Metadata>" from "next".