### PR TITLE
fix: do not add the same page twice in the sidebar tree

### DIFF
--- a/packages/core/src/source/page-tree/builder.ts
+++ b/packages/core/src/source/page-tree/builder.ts
@@ -27,6 +27,7 @@ export interface PageTreeBuilderContext<
 
   storages?: Record<string, ContentStorage<Page, Meta>>;
   locale?: string;
+  visitedPages?: Set<string>;
 }
 
 export interface PageTreeTransformer<
@@ -301,9 +302,14 @@ function buildFileNode(
   path: string,
   ctx: PageTreeBuilderContext,
 ): PageTree.Item | undefined {
-  const { options, getUrl, storage, locale, transformers } = ctx;
+  const { options, getUrl, storage, locale, transformers, visitedPages } = ctx;
+
+  if (visitedPages?.has(path)) return;
+
   const page = storage.read(path);
   if (page?.format !== 'page') return;
+
+  visitedPages?.add(path);
 
   const { title, description, icon } = page.data;
   let item: PageTree.Item = {
@@ -400,6 +406,7 @@ export function createPageTreeBuilder(getUrl: UrlFn): PageTreeBuilder {
           locale,
           storage,
           storages,
+          visitedPages: new Set<string>(),
           resolveName(name, format) {
             return resolve(name, format) ?? name;
           },

--- a/packages/core/test/loader.test.ts
+++ b/packages/core/test/loader.test.ts
@@ -252,3 +252,132 @@ test('Loader: Rest operator', () => {
       }
     `);
 });
+
+test('Loader: No duplicate pages when referencing subfolder items and folder', () => {
+  const result = loader({
+    baseUrl: '/',
+    pageTree: {
+      noRef: true,
+    },
+    source: {
+      files: [
+        {
+          type: 'meta',
+          path: 'meta.json',
+          data: {
+            pages: [
+              'index',
+              'subfolder/page1', // Reference specific page in subfolder
+              'subfolder/page2', // Reference another specific page
+              'other-page',
+              'subfolder', // Reference the entire folder
+            ],
+          },
+        },
+        {
+          type: 'page',
+          path: 'index.mdx',
+          data: {
+            title: 'Home',
+          },
+        },
+        {
+          type: 'page',
+          path: 'other-page.mdx',
+          data: {
+            title: 'Other Page',
+          },
+        },
+        {
+          type: 'page',
+          path: 'subfolder/page1.mdx',
+          data: {
+            title: 'Subfolder Page 1',
+          },
+        },
+        {
+          type: 'page',
+          path: 'subfolder/page2.mdx',
+          data: {
+            title: 'Subfolder Page 2',
+          },
+        },
+        {
+          type: 'page',
+          path: 'subfolder/page3.mdx',
+          data: {
+            title: 'Subfolder Page 3',
+          },
+        },
+      ],
+    },
+  });
+
+  // Check that pages are not duplicated
+  const pages = result.getPages();
+  const pagePaths = pages.map((page) => page.slugs.join('/'));
+
+  // Should have exactly 5 pages total
+  expect(pages.length).toBe(5);
+
+  // Check that each page appears only once
+  const uniquePaths = new Set(pagePaths);
+  expect(uniquePaths.size).toBe(pagePaths.length);
+
+  // Verify all pages are present
+  expect(pagePaths.sort()).toEqual([
+    '', // index
+    'other-page',
+    'subfolder/page1',
+    'subfolder/page2',
+    'subfolder/page3',
+  ]);
+
+  // Check the page tree structure
+  expect(removeUndefined(result.pageTree, true), 'Page Tree')
+    .toMatchInlineSnapshot(`
+      {
+        "$id": "root",
+        "children": [
+          {
+            "$id": "index.mdx",
+            "name": "Home",
+            "type": "page",
+            "url": "/",
+          },
+          {
+            "$id": "subfolder/page1.mdx",
+            "name": "Subfolder Page 1",
+            "type": "page",
+            "url": "/subfolder/page1",
+          },
+          {
+            "$id": "subfolder/page2.mdx",
+            "name": "Subfolder Page 2",
+            "type": "page",
+            "url": "/subfolder/page2",
+          },
+          {
+            "$id": "other-page.mdx",
+            "name": "Other Page",
+            "type": "page",
+            "url": "/other-page",
+          },
+          {
+            "$id": "subfolder",
+            "children": [
+              {
+                "$id": "subfolder/page3.mdx",
+                "name": "Subfolder Page 3",
+                "type": "page",
+                "url": "/subfolder/page3",
+              },
+            ],
+            "name": "Subfolder",
+            "type": "folder",
+          },
+        ],
+        "name": "",
+      }
+    `);
+});


### PR DESCRIPTION
Currently if you reference a page in a subfolder in `meta.json` and use `...` or the name of the same subfolder the page will be included twice in the tree

I added a visitedPages set to prevent having the same page showing twice in the tree