### PR TITLE
OpenAPI: Support legacy API path specs

### DIFF
--- a/.changeset/dry-wombats-know.md
+++ b/.changeset/dry-wombats-know.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-openapi': minor
+---
+
+Enhance resolveRequestData to support query parameters in path (legacy OpenAPI behavior)

--- a/.changeset/silly-turkeys-rule.md
+++ b/.changeset/silly-turkeys-rule.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-openapi': minor
+---
+
+Enhance generateFiles to create an index file for the overall ingested OpenAPI document

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -101,6 +101,32 @@ export async function generateAll(
   );
 }
 
+export async function generateIndexOnly(
+  schemaId: string,
+  processed: ProcessedDocument,
+  options: GenerateOptions = {},
+): Promise<string> {
+  const { document } = processed;
+
+  return generateDocument(
+    schemaId,
+    processed,
+    {
+      operations: [], // Empty - no operations
+      webhooks: [], // Empty - no webhooks
+      hasHead: false, // No operation headings
+    },
+    {
+      ...options,
+      title: document.info.title,
+      description: document.info.description,
+    },
+    {
+      type: 'file',
+    },
+  );
+}
+
 export async function generatePages(
   schemaId: string,
   processed: ProcessedDocument,

--- a/packages/openapi/src/utils/url.ts
+++ b/packages/openapi/src/utils/url.ts
@@ -1,7 +1,6 @@
 import type { RequestData } from '@/requests/_shared';
 
 export function joinURL(base: string, pathname: string): string {
-  debugger;
   if (pathname.startsWith('/')) pathname = pathname.slice(1);
   if (base.endsWith('/')) base = base.slice(0, -1);
 

--- a/packages/openapi/src/utils/url.ts
+++ b/packages/openapi/src/utils/url.ts
@@ -35,6 +35,7 @@ export function resolveRequestData(
   pathname: string,
   { path, query }: RequestData,
 ): string {
+  // First, resolve path parameters in the pathname
   for (const key in path) {
     const param = path[key];
 
@@ -45,18 +46,28 @@ export function resolveRequestData(
     }
   }
 
-  const searchParams = new URLSearchParams();
+  // Check if pathname already contains query parameters (legacy API support)
+  const [pathPart, existingQueryString] = pathname.split('?', 2);
+
+  // Parse existing query parameters from the pathname if they exist
+  const searchParams = new URLSearchParams(existingQueryString || '');
+
+  // Add new query parameters from the RequestData
   for (const key in query) {
     const param = query[key];
 
     if (Array.isArray(param.value)) {
+      // Remove existing parameter first to avoid duplicates
+      searchParams.delete(key);
       for (const item of param.value) {
         searchParams.append(key, item);
       }
     } else {
-      searchParams.append(key, param.value);
+      // Set (replace if exists) the parameter value
+      searchParams.set(key, param.value);
     }
   }
 
-  return searchParams.size > 0 ? `${pathname}?${searchParams}` : pathname;
+  // Return the reconstructed URL
+  return searchParams.size > 0 ? `${pathPart}?${searchParams}` : pathPart;
 }

--- a/packages/openapi/src/utils/url.ts
+++ b/packages/openapi/src/utils/url.ts
@@ -1,6 +1,7 @@
 import type { RequestData } from '@/requests/_shared';
 
 export function joinURL(base: string, pathname: string): string {
+  debugger;
   if (pathname.startsWith('/')) pathname = pathname.slice(1);
   if (base.endsWith('/')) base = base.slice(0, -1);
 


### PR DESCRIPTION
Motivation: Legacy APIs do not follow RESTful guidelines whereby an
API path has multiple query parameters that alter the response or
behavior of the operation. Examples: `/api/foo/bar?verbose=true`
can provide different response output, or
`/api/location/search?name=foo` can work differently than
`/api/location/search?lat=10,long=10` (but ultimately belong to
the same API).

* Update resolveRequestData to support legacy behavior of query params
in the `path` item of an OpenAPI document. This fixes where
`path?name?name=param` gets used in the code samples.