### PR TITLE
Allow passing query params in search `api` field

### DIFF
--- a/packages/core/src/search/client/fetch.ts
+++ b/packages/core/src/search/client/fetch.ts
@@ -26,10 +26,11 @@ export async function fetchDocs(
   { api = '/api/search', locale, tag }: FetchOptions,
 ): Promise<SortedResult[]> {
   const url = new URL(api, window.location.origin);
-  
+
   url.searchParams.set('query', query);
   if (locale) url.searchParams.set('locale', locale);
-  if (tag) url.searchParams.set('tag', Array.isArray(tag) ? tag.join(',') : tag);
+  if (tag)
+    url.searchParams.set('tag', Array.isArray(tag) ? tag.join(',') : tag);
 
   const key = `${url.pathname}?${url.searchParams}`;
   const cached = cache.get(key);


### PR DESCRIPTION
Previously api was assumed to always be a path without query params. Now it can have query params, which will be added to the search endpoint