### PR TITLE
Modify styles for code diff lines and padding for inline code in shiki.css

### DIFF
--- a/packages/ui/css/shiki.css
+++ b/packages/ui/css/shiki.css
@@ -6,6 +6,11 @@
     color: var(--shiki-light);
   }
 
+  span > code > span {
+    --padding-left: var(--spacing);
+    --padding-right: var(--spacing);
+  }
+
   code .line.diff {
     --padding-left: calc(var(--spacing) * 5);
     --padding-right: calc(var(--spacing) * 5);


### PR DESCRIPTION
This pull request makes minor improvements to the styling of diff lines in the `shiki.css` file, focusing on padding and alignment for better readability.

Styling improvements for diff lines:

* Added custom left and right padding for lines with the `diff` class inside `code` blocks to improve visual spacing.
* Adjusted the position of the `::before` pseudo-element on `.diff` lines to align better by doubling the left offset.

This pull request introduces improvements to the styling of code blocks in the `shiki.css` file, specifically focusing on enhancing padding and alignment for code spans and diff lines.

Styling enhancements for code and diffs:

* Added custom left and right padding variables for `span > code > span` elements to improve spacing within code blocks.
* Increased padding for `.line.diff` elements to make diff lines stand out more clearly in code blocks.
* Adjusted the left position of the `code .diff::before` pseudo-element to improve visual alignment, doubling the previous spacing.


<table>
<thead>
<th> Before </th>
<th> After </th>
</thead>
<tbody>
<td> 
<img width="1102" height="120" alt="{F1F112BD-70CE-47F3-B04E-6E18E6DA3189}" src="https://github.com/user-attachments/assets/1d04f74d-eb80-4349-9bf1-05e1ce31db4a" />
<img width="485" height="54" alt="{E21944AB-EE24-45DB-B897-3ED507FAC8FF}" src="https://github.com/user-attachments/assets/b42f5290-0e87-4493-b584-86ff7352ff7b" />
  </td>
<td> 
<img width="1099" height="131" alt="{4A70B869-FD13-4820-977A-112E5D728640}" src="https://github.com/user-attachments/assets/4bf49e70-31b4-4452-8e1a-69f4fa805c8d" />
<img width="462" height="35" alt="{FFD584F2-D7D5-43B4-B8F5-7EEA87BF896D}" src="https://github.com/user-attachments/assets/ed1689e2-5234-4941-a989-ec266fbc62b1" />
  </td>
</tbody>
</table>

**Before**:
<img width="1102" height="120" alt="{F1F112BD-70CE-47F3-B04E-6E18E6DA3189}" src="https://github.com/user-attachments/assets/1d04f74d-eb80-4349-9bf1-05e1ce31db4a" />

<img width="485" height="54" alt="{E21944AB-EE24-45DB-B897-3ED507FAC8FF}" src="https://github.com/user-attachments/assets/b42f5290-0e87-4493-b584-86ff7352ff7b" />

**After**:
<img width="1099" height="131" alt="{4A70B869-FD13-4820-977A-112E5D728640}" src="https://github.com/user-attachments/assets/4bf49e70-31b4-4452-8e1a-69f4fa805c8d" />

<img width="462" height="35" alt="{FFD584F2-D7D5-43B4-B8F5-7EEA87BF896D}" src="https://github.com/user-attachments/assets/ed1689e2-5234-4941-a989-ec266fbc62b1" />