### PR TITLE
Docs: Add 'Except' item to Routing docs

### DIFF
--- a/apps/docs/content/docs/headless/page-conventions.mdx
+++ b/apps/docs/content/docs/headless/page-conventions.mdx
@@ -145,7 +145,7 @@ Special Items:
 - **Rest** (`...`): include remaining pages (sorted alphabetically).
 - **Reversed Rest** (`z...a`): reversed **Rest** item.
 - **Extract** (`...folder`): extract the items from a folder.
-- **Except** (`!item`): Exclude the item.
+- **Except** (`!item`): Exclude an item from `...` or `z...a`.
 
 ```json title="meta.json"
 {

--- a/apps/docs/content/docs/headless/page-conventions.mdx
+++ b/apps/docs/content/docs/headless/page-conventions.mdx
@@ -143,8 +143,9 @@ Folder items are sorted alphabetically by default, you can add or control the or
 Special Items:
 
 - **Rest** (`...`): include remaining pages (sorted alphabetically).
-- **Reversed Rest** (`z...a`): reversed **Rest** item,
+- **Reversed Rest** (`z...a`): reversed **Rest** item.
 - **Extract** (`...folder`): extract the items from a folder.
+- **Except** (`!item`): Exclude the item.
 
 ```json title="meta.json"
 {
@@ -153,6 +154,8 @@ Special Items:
     "---My Separator---",
     "...folder",
     "...",
+    "!file",
+    "!otherFolder",
     "[Vercel](https://vercel.com)",
     "[Triangle][Vercel](https://vercel.com)"
   ]


### PR DESCRIPTION
I'm not sure when this was removed or if there was a specific reason for it, but I did some digging and found that the functionality did exist. So I decided to add it back to the docs

