### PR TITLE
Fix React Router template imports

### DIFF
--- a/.changeset/whole-ghosts-laugh.md
+++ b/.changeset/whole-ghosts-laugh.md
@@ -1,0 +1,5 @@
+---
+'create-fumadocs-app': patch
+---
+
+Fixed imports for the React Router template.

--- a/packages/create-app/template/react-router/app/docs/search.ts
+++ b/packages/create-app/template/react-router/app/docs/search.ts
@@ -1,6 +1,6 @@
 import type { Route } from './+types/search';
 import { createFromSource } from 'fumadocs-core/search/server';
-import { source } from '@/source';
+import { source } from '@/lib/source';
 
 const server = createFromSource(source, {
   // https://docs.orama.com/docs/orama-js/supported-languages

--- a/packages/create-app/template/react-router/app/lib/source.ts
+++ b/packages/create-app/template/react-router/app/lib/source.ts
@@ -1,5 +1,5 @@
 import { loader } from 'fumadocs-core/source';
-import { create, docs } from '../source.generated';
+import { create, docs } from '../../source.generated';
 
 export const source = loader({
   source: await create.sourceAsync(docs.doc, docs.meta),


### PR DESCRIPTION
Resolves #2295 and resolves another import error in packages/create-app/template/react-router/app/docs/search.ts.