### PR TITLE
fix: fix description inclusion based on includeDescription flag

### DIFF
--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -316,7 +316,7 @@ function generatePage(
   return generateDocument(
     {
       title: options.title,
-      description: !includeDescription ? options.description : undefined,
+      description: includeDescription ? options.description : undefined,
       full: true,
       ...extend,
       _openapi: {


### PR DESCRIPTION
Currently, this code will cause the generated mdx files to include `description:` frontmatter.

```ts
await OpenAPI.generateFiles({
    input: openapi,
    output: out,
    includeDescription: false,
})
```

This PR corrects the logic to fix it.