### PR TITLE
OpenAPI: handle undefined description in index.md generation

### DIFF
--- a/.changeset/chilled-bikes-think.md
+++ b/.changeset/chilled-bikes-think.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-openapi": patch
+---
+
+OpenAPI: handle undefined description in index.md generation

--- a/packages/openapi/src/generate-file.ts
+++ b/packages/openapi/src/generate-file.ts
@@ -481,8 +481,9 @@ function writeIndexFiles(context: HookContext, options: Config) {
       const { data } = matter(file.content);
       if (typeof data.title !== 'string') continue;
 
+      const descriptionAttr = data.description ? `description=${JSON.stringify(data.description)} ` : '';
       content.push(
-        `<Card href="${urlFn(file.path)}" title=${JSON.stringify(data.title)} description=${JSON.stringify(data.description)} />`,
+        `<Card href="${urlFn(file.path)}" title=${JSON.stringify(data.title)} ${descriptionAttr}/>`,
       );
     }
 


### PR DESCRIPTION
Reference documentation: [openapi/configurations](https://fumadocs.dev/docs/ui/openapi/configurations#index)  
Previous version logic: When the page frontmatter does not contain a description, the Card Component would display:  
```
<Card href="/docs/api_endpoint" title="title" description=undefined />
```  
This would cause a page compilation error.  
This PR fixes the issue.  

Additionally: The description field from my OpenAPI Schema does not seem to be included in the frontmatter. Instead, it is placed under:  
```
_openapi:
  method: GET
  route: /tasks/{task_id}
  toc: []
  structuredData:
    headings: []
    contents:
      - content: {{MY_DESCRIPTION}}
```  
Is this the expected behavior or a bug?  
I would be happy to submit further PRs. Thank you!