### PR TITLE
chore: point createMDXSource imports to runtime/next

### DIFF
--- a/apps/docs/content/blog/make-a-blog.mdx
+++ b/apps/docs/content/blog/make-a-blog.mdx
@@ -35,7 +35,7 @@ export const blogPosts = defineCollections({
 Parse the output collection in `source.ts`:
 
 ```ts title="lib/source.ts"
-import { createMDXSource } from 'fumadocs-mdx';
+import { createMDXSource } from 'fumadocs-mdx/runtime/next';
 import { loader } from 'fumadocs-core/source';
 import { blogPosts } from '@/.source';
 

--- a/apps/docs/content/blog/mdx-v10-summary.mdx
+++ b/apps/docs/content/blog/mdx-v10-summary.mdx
@@ -108,7 +108,7 @@ Now to integrate it with Fumadocs framework, change your `source.ts` from:
 
 ```ts
 import { map } from '@/.map';
-import { createMDXSource } from 'fumadocs-mdx';
+import { createMDXSource } from 'fumadocs-mdx/runtime/next';
 import { loader } from 'fumadocs-core/source';
 
 export const { getPage, getPages, pageTree } = loader({
@@ -122,7 +122,7 @@ to:
 
 ```ts
 import { docs, meta } from '@/.source';
-import { createMDXSource } from 'fumadocs-mdx';
+import { createMDXSource } from 'fumadocs-mdx/runtime/next';
 import { loader } from 'fumadocs-core/source';
 
 export const source = loader({
@@ -171,7 +171,7 @@ For `defineDocs`, see [`schema`](/docs/mdx/collections#schema-1).
 Same as before, you can call `loader` multiple times for different types (e.g. for docs and blog).
 
 ```ts
-import { createMDXSource } from 'fumadocs-mdx';
+import { createMDXSource } from 'fumadocs-mdx/runtime/next';
 import type { InferMetaType, InferPageType } from 'fumadocs-core/source';
 import { loader } from 'fumadocs-core/source';
 import { meta, docs, blog as blogPosts } from '@/.source';

--- a/apps/docs/content/blog/mdx-v10.mdx
+++ b/apps/docs/content/blog/mdx-v10.mdx
@@ -61,7 +61,7 @@ This model works, but we started to see some problems:
 
   ```ts
   import { loader } from 'fumadocs-core/source';
-  import { createMDXSource } from 'fumadocs-mdx';
+  import { createMDXSource } from 'fumadocs-mdx/runtime/next';
 
   export const source = loader({
     source: createMDXSource(map, {

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -1,4 +1,4 @@
-import { createMDXSource } from 'fumadocs-mdx';
+import { createMDXSource } from 'fumadocs-mdx/runtime/next';
 import type { InferMetaType, InferPageType } from 'fumadocs-core/source';
 import { loader } from 'fumadocs-core/source';
 import { icons } from 'lucide-react';

--- a/examples/i18n/lib/source.ts
+++ b/examples/i18n/lib/source.ts
@@ -1,4 +1,4 @@
-import { createMDXSource } from 'fumadocs-mdx';
+import { createMDXSource } from 'fumadocs-mdx/runtime/next';
 import { loader } from 'fumadocs-core/source';
 import { i18n } from '@/lib/i18n';
 import { docs, meta } from '@/.source';

--- a/examples/openapi/lib/source.ts
+++ b/examples/openapi/lib/source.ts
@@ -1,4 +1,4 @@
-import { createMDXSource } from 'fumadocs-mdx';
+import { createMDXSource } from 'fumadocs-mdx/runtime/next';
 import { loader } from 'fumadocs-core/source';
 import { openapiPlugin } from 'fumadocs-openapi/server';
 import { docs, meta } from '@/.source';

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -2,6 +2,6 @@ export type * from './runtime/shared';
 
 // backward compat
 // TODO: require importing `fumadocs-mdx/runtime/next` instead
-export * from './next';
+export * from './runtime/next';
 
 export type { ExtractedReference } from '@/loaders/mdx/remark-postprocess';

--- a/packages/mdx/src/next/map/generate.ts
+++ b/packages/mdx/src/next/map/generate.ts
@@ -27,7 +27,7 @@ export async function generateJS(
     getImportCode({
       type: 'named',
       names: ['_runtime'],
-      specifier: 'fumadocs-mdx',
+      specifier: 'fumadocs-mdx/runtime/next',
     }),
     getImportCode({
       type: 'namespace',


### PR DESCRIPTION
the builds were failing with the updated index export in df7e0a6cb1d0d5ecdd4a8a809462d890ed0853b0. updated the imports to fix the build