### PR TITLE
fix: Add focus ring to buttonVariants

### DIFF
--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -9,7 +9,7 @@ const variants = {
 } as const;
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none',
+  'inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring',
   {
     variants: {
       variant: variants,


### PR DESCRIPTION
Add missing ring classes for buttonVariants to ensure focus states are visible for buttons.


https://github.com/user-attachments/assets/0a192664-abde-4914-8ff9-4e72a03489ab



