### PR TITLE
fix (api): api page response accordion for single content types.

### DIFF
--- a/packages/openapi/src/render/operation/index.tsx
+++ b/packages/openapi/src/render/operation/index.tsx
@@ -290,16 +290,19 @@ async function ResponseAccordion({
 }) {
   const response = operation.responses![status];
   const { generateTypeScriptSchema } = ctx;
-  const contentTypes = response.content
-    ? Object.entries(response.content)
-    : null;
+  const contentTypes = response.content ? Object.entries(response.content) : [];
 
   return (
-    <SelectTabs defaultValue={contentTypes?.[0][0]}>
+    <SelectTabs defaultValue={contentTypes.at(0)?.[0]}>
       <AccordionHeader>
         <AccordionTrigger className="font-mono">{status}</AccordionTrigger>
-        {contentTypes && contentTypes.length > 1 && (
+        {contentTypes.length > 1 && (
           <SelectTabTrigger items={contentTypes.map((v) => v[0])} />
+        )}
+        {contentTypes.length === 1 && (
+          <p className="text-[13px] text-fd-muted-foreground">
+            {contentTypes[0][0]}
+          </p>
         )}
       </AccordionHeader>
 


### PR DESCRIPTION
## Problem
The content types in the response accordion had a bug — when only a single contentType was present, it incorrectly entered a selection state, causing unintended UI behavior.

<img width="734" height="169" alt="image" src="https://github.com/user-attachments/assets/ea424a36-68f5-41df-aba9-51cea2ef4725" />

## Solution
If there’s only one contentType, it’s now hidden by default to prevent the unnecessary selection state.

