### PR TITLE
Add showTitle option to tableOfContent and id to style it

### DIFF
--- a/.changeset/gold-toes-smell.md
+++ b/.changeset/gold-toes-smell.md
@@ -2,4 +2,4 @@
 'fumadocs-ui': patch
 ---
 
-Add showTitle option to tableOfContent and id to style it
+Add a `toc-title` ID to the table of contents heading for styling purposes

--- a/apps/docs/content/docs/ui/(ui)/layouts/page.mdx
+++ b/apps/docs/content/docs/ui/(ui)/layouts/page.mdx
@@ -108,6 +108,8 @@ import { DocsPage } from 'fumadocs-ui/page';
 </DocsPage>;
 ```
 
+You can also style the TOC title with the `toc-title` ID.
+
 ### Last Updated Time
 
 Display last updated time of the page.

--- a/packages/ui/src/page.tsx
+++ b/packages/ui/src/page.tsx
@@ -97,28 +97,6 @@ type TableOfContentOptions = Pick<AnchorProviderProps, 'single'> & {
    * @defaultValue 'normal'
    */
   style?: 'normal' | 'clerk';
-  /**
-   * Displays a title at the top of the Table of Contents.
-   * The default title is "On this page," but it can be customized with i18n in the RootProvider.
-   * @example
-   * ```ts
-   * import { defaultTranslations } from "fumadocs-ui/i18n";
-   * import { RootProvider } from "fumadocs-ui/provider";
-   * //...
-   * <RootProvider
-   *   i18n={{
-   *     translations: {
-   *       ...defaultTranslations,
-   *       toc: "Table of Contents",
-   *     },
-   *   }}
-   * >
-   *   {children}
-   * </RootProvider>
-   * ```
-   * @default true
-   */
-  showTitle?: boolean;
 };
 
 type TableOfContentPopoverOptions = Omit<TableOfContentOptions, 'single'>;
@@ -142,7 +120,6 @@ export function DocsPage({
   tableOfContent: {
     enabled: tocEnabled,
     component: tocReplace,
-    showTitle = true,
     ...tocOptions
   } = {},
   toc = [],
@@ -203,7 +180,7 @@ export function DocsPage({
         (tocReplace ?? (
           <PageTOC>
             {tocOptions.header}
-            {showTitle && <PageTOCTitle />}
+            <PageTOCTitle />
             <PageTOCItems variant={tocOptions.style} />
             {tocOptions.footer}
           </PageTOC>


### PR DESCRIPTION
Following [this discussion](https://github.com/fuma-nama/fumadocs/discussions/933#discussioncomment-14725960).

There really wasn't a way to hide it with Translations API. The best thing I could do was change it to an empty string but the icon and space remained visible.

Also, it wasn’t easy to hide it with CSS because it didn’t have any specific selector, so I added an ID to it.

I build the docs and verify that works correctly with `true`, `false` and `undefined`.

