### PR TITLE
fix(docs/lib): Guard `page.data.description` to prevent rendering `undefined` in generated LLM text

### DIFF
--- a/apps/docs/lib/get-llm-text.ts
+++ b/apps/docs/lib/get-llm-text.ts
@@ -17,7 +17,7 @@ export async function getLLMText(page: Page) {
 URL: ${page.url}
 Source: https://raw.githubusercontent.com/fuma-nama/fumadocs/refs/heads/main/apps/docs/content/docs/${page.path}
 
-${page.data.description}
+${page.data.description ?? ''}
         
 ${processed}`;
 }


### PR DESCRIPTION

## Description

## What
- Add a nullish coalescing guard (`?? ''`) to `page.data.description` so the template does not print the literal `undefined` when `description` is missing.

## Why
While the docs usually define a `description` for each MDX page, readers may copy this utility directly from the repository or create new pages that omit the field. In such cases, the current code renders:
```markdown
undefined
