### PR TITLE
fix(openapi): filter empty query parameters, headers, and cookies

### DIFF
--- a/packages/openapi/src/playground/fetcher.ts
+++ b/packages/openapi/src/playground/fetcher.ts
@@ -38,13 +38,17 @@ export function createBrowserFetcher(
 
         if (!Array.isArray(param.value)) {
           // Only append non-empty header values
-          if (param.value !== '' && param.value !== null && param.value !== undefined) {
+          if (
+            param.value !== '' &&
+            param.value !== null &&
+            param.value !== undefined
+          ) {
             headers.append(key, param.value);
           }
         } else {
           // Filter out empty values from array
           const nonEmptyValues = param.value.filter(
-            (v) => v !== '' && v !== null && v !== undefined
+            (v) => v !== '' && v !== null && v !== undefined,
           );
           if (nonEmptyValues.length > 0) {
             headers.append(key, nonEmptyValues.join(','));
@@ -77,9 +81,13 @@ export function createBrowserFetcher(
       // cookies
       for (const key in options.cookie) {
         const param = options.cookie[key];
-        
+
         // Only set non-empty cookie values
-        if (param.value !== '' && param.value !== null && param.value !== undefined) {
+        if (
+          param.value !== '' &&
+          param.value !== null &&
+          param.value !== undefined
+        ) {
           const segs: string[] = [`${key}=${param.value}`];
 
           if (proxyUrl && proxyUrl.origin !== window.location.origin)

--- a/packages/openapi/src/utils/url.ts
+++ b/packages/openapi/src/utils/url.ts
@@ -71,7 +71,11 @@ export function resolveRequestData(
       }
     } else {
       // Only set parameter if value is not empty
-      if (param.value !== '' && param.value !== null && param.value !== undefined) {
+      if (
+        param.value !== '' &&
+        param.value !== null &&
+        param.value !== undefined
+      ) {
         searchParams.set(key, param.value);
       }
     }


### PR DESCRIPTION
Fixes https://github.com/fuma-nama/fumadocs/issues/2530

### Changes

- Filter out empty (`''`, `null`, `undefined`) values from query parameters in `url.ts`
- Filter out empty values from headers and cookies in `fetcher.ts`
- Prevents invalid URLs like `?pageToken=` from appearing in requests and code examples

### Before
```bash
curl -X GET "https://api.example.com/endpoint?pageToken=&pageSize=10"
```

### After
```bash
curl -X GET "https://api.example.com/endpoint?pageSize=10"
```

### Testing
Tested with linked local package for Avalanche Data/Metrics API on build.avax.network. Empty pagination parameters no longer break API requests or clutter code examples. 

Users can still input values when needed; empty fields are simply excluded from the request.