### PR TITLE
Use path aliases in Astro example

### DIFF
--- a/examples/astro/src/pages/[...slug].astro
+++ b/examples/astro/src/pages/[...slug].astro
@@ -1,10 +1,10 @@
 ---
 import { render, type CollectionEntry } from 'astro:content';
-import { Docs } from '../components/docs';
+import { Docs } from '@/components/docs';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
-import '../styles/global.css';
-import { source } from '../lib/source';
-import Layout from '../components/layout.astro';
+import '@/styles/global.css';
+import { source } from '@/lib/source';
+import Layout from '@/components/layout.astro';
 import type { TOCItemType } from 'fumadocs-core/toc';
 
 interface Props {

--- a/examples/astro/src/pages/api/search.ts
+++ b/examples/astro/src/pages/api/search.ts
@@ -1,12 +1,11 @@
 import type { APIRoute } from 'astro';
 import { createFromSource } from 'fumadocs-core/search/server';
-import { getFullExport, source } from '../../lib/source';
+import { getFullExport, source } from '@/lib/source';
 import { getBreadcrumbItems } from 'fumadocs-core/breadcrumb';
 
 const server = createFromSource(source, {
   async buildIndex(page) {
     const { structuredData } = await getFullExport(page.data._raw);
-    console.log(structuredData);
 
     return {
       id: page.data._raw.id,

--- a/examples/astro/tsconfig.json
+++ b/examples/astro/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
 }


### PR DESCRIPTION
Updated import statements to use '@' path aliases in Astro example files and configured TypeScript with baseUrl and paths for cleaner imports.

Removed a console.log that ran on every build.