### PR TITLE
Add `storageKey` option to isolate localStorage for multiple API instances

### DIFF
--- a/.changeset/multiple-api-storage-isolation.md
+++ b/.changeset/multiple-api-storage-isolation.md
@@ -1,0 +1,28 @@
+---
+'fumadocs-openapi': minor
+---
+
+Add `storageKey` option to isolate localStorage for multiple API instances
+
+When using multiple `createOpenAPI()` instances in the same application, the server selection state would bleed between different APIs because they all shared the same hardcoded `'apiBaseUrl'` localStorage key.
+
+**Changes:**
+- Added `storageKey` parameter to `SharedOpenAPIOptions` interface
+- Updated `ApiProvider` to accept and use custom storage keys
+- Defaults to `'apiBaseUrl'` for backward compatibility
+
+**Usage:**
+```typescript
+export const dataApi = createOpenAPI({
+  input: ['./openapi/data.json'],
+  storageKey: 'apiBaseUrl-data',
+});
+
+export const metricsApi = createOpenAPI({
+  input: ['./openapi/metrics.json'],
+  storageKey: 'apiBaseUrl-metrics',
+});
+```
+
+Each API instance now maintains independent server selection state.
+

--- a/packages/openapi/src/server/create.tsx
+++ b/packages/openapi/src/server/create.tsx
@@ -81,6 +81,15 @@ export interface SharedOpenAPIOptions {
      */
     showExampleInFields?: boolean;
   };
+
+  /**
+   * Custom localStorage key for server selection.
+   * 
+   * Useful when using multiple OpenAPI instances to prevent state conflicts.
+   *
+   * @defaultValue 'apiBaseUrl'
+   */
+  storageKey?: string;
 }
 
 export interface OpenAPIOptions extends SharedOpenAPIOptions {

--- a/packages/openapi/src/ui/contexts/api.tsx
+++ b/packages/openapi/src/ui/contexts/api.tsx
@@ -19,6 +19,12 @@ export interface ApiProviderProps
   defaultBaseUrl?: string;
   children?: ReactNode;
   mediaAdapters?: Record<string, MediaAdapter>;
+  /**
+   * Custom localStorage key for server selection.
+   * 
+   * @defaultValue 'apiBaseUrl'
+   */
+  storageKey?: string;
 }
 
 export interface SelectedServer {
@@ -61,6 +67,7 @@ export function ApiProvider({
   servers,
   mediaAdapters,
   shikiOptions,
+  storageKey = 'apiBaseUrl',
 }: ApiProviderProps) {
   const [server, setServer] = useState<SelectedServer | null>(() => {
     const defaultItem = defaultBaseUrl
@@ -76,7 +83,7 @@ export function ApiProvider({
   });
 
   useEffect(() => {
-    const cached = localStorage.getItem('apiBaseUrl');
+    const cached = localStorage.getItem(storageKey);
     if (!cached) return;
 
     try {
@@ -87,7 +94,7 @@ export function ApiProvider({
     } catch {
       // ignore
     }
-  }, []);
+  }, [storageKey]);
 
   return (
     <ApiContext.Provider
@@ -112,7 +119,7 @@ export function ApiProvider({
                 if (!prev) return null;
 
                 const updated = { ...prev, variables };
-                localStorage.setItem('apiBaseUrl', JSON.stringify(updated));
+                localStorage.setItem(storageKey, JSON.stringify(updated));
                 return updated;
               });
             },
@@ -125,11 +132,11 @@ export function ApiProvider({
                 variables: getDefaultValues(obj),
               };
 
-              localStorage.setItem('apiBaseUrl', JSON.stringify(result));
+              localStorage.setItem(storageKey, JSON.stringify(result));
               setServer(result);
             },
           }),
-          [server, servers],
+          [server, servers, storageKey],
         )}
       >
         {children}

--- a/packages/openapi/src/ui/index.tsx
+++ b/packages/openapi/src/ui/index.tsx
@@ -23,6 +23,7 @@ export function Root({
         mediaAdapters={mediaAdapters}
         servers={ctx.servers}
         shikiOptions={ctx.shikiOptions}
+        storageKey={ctx.storageKey}
       >
         {children}
       </ApiProvider>


### PR DESCRIPTION
## Summary

Adds an optional `storageKey` parameter to `createOpenAPI()` that allows multiple API instances to maintain independent server selection state in localStorage.

Fixes #2554

## Problem

When using multiple `createOpenAPI()` instances in the same application (e.g., for different APIs like Data API, Metrics API, RPC APIs), the server selection state bleeds between different APIs. This happens because fumadocs-openapi uses a hardcoded `'apiBaseUrl'` localStorage key shared across all instances.

**Reproduction:**
1. Create two OpenAPI instances for different APIs
2. Navigate to API 1 and select a server URL
3. Navigate to API 2
4. **Bug**: API 2 shows the server URL from API 1

This is particularly noticeable in production builds (Vercel deployments) due to Next.js component reuse optimizations.

## Solution

Added an optional `storageKey` parameter to `SharedOpenAPIOptions` that allows each API instance to use a unique localStorage key while maintaining backward compatibility.

## Changes

### 1. `packages/openapi/src/server/create.tsx`
- Added `storageKey?: string` to `SharedOpenAPIOptions` interface with JSDoc

### 2. `packages/openapi/src/ui/contexts/api.tsx`
- Added `storageKey` parameter to `ApiProviderProps` (defaults to `'apiBaseUrl'`)
- Updated all `localStorage.getItem()` and `localStorage.setItem()` calls to use the custom key
- Added `storageKey` to relevant dependency arrays

### 3. `packages/openapi/src/ui/index.tsx`
- Pass `storageKey` from context to `ApiProvider`

### 4. `.changeset/multiple-api-storage-isolation.md`
- Added changeset documenting the changes

## Usage

```typescript
import { createOpenAPI } from 'fumadocs-openapi/server';

// Each API gets its own storage key
export const dataApi = createOpenAPI({
  input: ['./openapi/data.json'],
  storageKey: 'apiBaseUrl-data',
});

export const metricsApi = createOpenAPI({
  input: ['./openapi/metrics.json'],
  storageKey: 'apiBaseUrl-metrics',
});
```

Each API instance now maintains independent server selection in localStorage.

## Backward Compatibility

- ✅ Defaults to `'apiBaseUrl'` if not specified
- ✅ Existing code continues to work without any changes
- ✅ No breaking changes

## Testing

Tested with 4 different API instances (Data API, Metrics API, P-Chain RPC, C-Chain RPC) in a production application with multiple APIs. Server selection is now properly isolated between APIs in both development and production builds.

## Additional Context

This becomes critical for comprehensive documentation sites that host multiple APIs. Without this fix, users experience confusing behavior where selecting a server in one API section incorrectly affects other API sections.
