### PR TITLE
docs: Fix Next.js Dockerfile example for postinstall

### DIFF
--- a/apps/docs/content/docs/ui/deploying.mdx
+++ b/apps/docs/content/docs/ui/deploying.mdx
@@ -23,7 +23,7 @@ Use https://opennext.js.org/cloudflare, Fumadocs doesn't work on Edge runtime.
 
 ### Next.js + Docker
 
-If you want to deploy your Fumadocs app using Docker with **Fumadocs MDX configured**, make sure to add the `source.config.ts` file to the `WORKDIR` in the Dockerfile.
+If you want to deploy your Fumadocs app using Docker with **Fumadocs MDX configured**, make sure to add the `source.config.ts` file and your `next.config.js` file to the `WORKDIR` in the Dockerfile.
 The following snippet is taken from the official [Next.js Dockerfile Example](https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile):
 
 ```zsh title="Dockerfile"
@@ -38,7 +38,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager [!code highlight]
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* source.config.ts ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* source.config.ts next.config.* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \


### PR DESCRIPTION
This MR fixes an issue in the "Next.js + Docker" documentation that causes build failures in clean Docker environments.

### The Problem:

The current Dockerfile example for Next.js only instructs users to `COPY` the `source.config.ts` file into the deps stage. However, it omits the crucial `next.config.js` file (or its .mjs/.ts variants).

The `fumadocs-mdx` package contains a postinstall script that checks for the existence of a `next.config.js` file to determine if the project is a Next.js application.

https://github.com/fuma-nama/fumadocs/blob/117ad869eba3f3d3e9e0e4d2d05065bf22c13daf/packages/mdx/src/bin.ts#L7-L19


- If `next.config.js` is **found**, it runs the correct Next.js-specific logic.
- If `next.config.js` is **not found**, the script incorrectly assumes a Vite environment and attempts to execute Vite-specific logic. This fails with a `Cannot find package 'vite'` error if vite is not a project dependency, causing the entire `npm install/yarn/bun install` step to fail.

This leads to a confusing situation where a user's local build succeeds, but the Docker build fails for a seemingly unrelated reason.

### The Solution:

This MR updates the documentation and the example Dockerfile to include `next.config.js` and its variants (`.mjs, .ts`) in the `COPY` command of the `deps` stage.

By ensuring the Next.js config file is present during dependency installation, the `fumadocs-mdx` postinstall script can correctly identify the project type and complete successfully. This makes the documentation accurate and prevents build failures for users following the guide.