### PR TITLE
fix(ui): Scrollable Code Block Accessibility

### DIFF
--- a/.changeset/scrollable-codeblock-a11y.md
+++ b/.changeset/scrollable-codeblock-a11y.md
@@ -1,0 +1,6 @@
+---
+'fumadocs-ui': patch
+---
+
+Fix accessibility: Add keyboard focusability to scrollable code blocks to resolve scrollable-region-focusable violations
+

--- a/packages/ui/src/components/codeblock.tsx
+++ b/packages/ui/src/components/codeblock.tsx
@@ -7,8 +7,10 @@ import {
   type ReactNode,
   type RefObject,
   useContext,
+  useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import { cn } from '@/utils/cn';
 import { useCopyButton } from '@/utils/use-copy-button';
@@ -89,6 +91,24 @@ export function CodeBlock({
 }: CodeBlockProps) {
   const inTab = useContext(TabsContext) !== null;
   const areaRef = useRef<HTMLDivElement>(null);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useEffect(() => {
+    const element = areaRef.current;
+    if (!element) return;
+
+    const checkScrollable = () => {
+      const hasVerticalScroll = element.scrollHeight > element.clientHeight;
+      const hasHorizontalScroll = element.scrollWidth > element.clientWidth;
+      setIsScrollable(hasVerticalScroll || hasHorizontalScroll);
+    };
+
+    checkScrollable();
+    const observer = new ResizeObserver(checkScrollable);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <figure
@@ -147,6 +167,11 @@ export function CodeBlock({
             ...viewportProps.style,
           } as object
         }
+        {...(isScrollable && {
+          tabIndex: 0,
+          role: 'region',
+          'aria-label': 'Code block (use arrow keys to scroll)',
+        })}
       >
         {children}
       </div>


### PR DESCRIPTION
Added keyboard accessibility to scrollable code blocks in `fumadocs-ui`:

1. **Dynamic detection**: Uses ResizeObserver to detect when `.fd-scroll-container` is scrollable
2. **Conditional attributes**: Only adds accessibility attributes when actually scrollable:
   - `tabindex="0"` - Allows keyboard focus
   - `role="region"` - Identifies as scrollable region
   - `aria-label="Code block (use arrow keys to scroll)"` - Provides context for screen readers

**Bundle impact**: Minimal (ResizeObserver is native browser API)


Closes #2573 