### PR TITLE
add (openapi): added support for rendering schema properties in the oneOf types in SchemaUIContent

### DIFF
--- a/.changeset/clean-places-worry.md
+++ b/.changeset/clean-places-worry.md
@@ -1,5 +1,5 @@
 ---
-'fumadocs-openapi': major
+'fumadocs-openapi': patch
 ---
 
-Enhance SchemaUI to display properties in the client schema. Added support for rendering schema properties in the SchemaUIContent component and updated SchemaData type to include props with required status.
+Enhance Schema UI to display inherited properties for `oneOf`.

--- a/packages/openapi/src/ui/schema/client.tsx
+++ b/packages/openapi/src/ui/schema/client.tsx
@@ -124,7 +124,7 @@ function SchemaUIContent({ $type }: { $type: string }) {
   if ((schema.readOnly && !readOnly) || (schema.writeOnly && !writeOnly))
     return;
 
-  let child = <></>;
+  let child: ReactNode = null;
 
   if (schema.type === 'or' && schema.items.length > 0) {
     child = (
@@ -145,16 +145,6 @@ function SchemaUIContent({ $type }: { $type: string }) {
               forceMount={undefined}
               className="py-0"
             >
-              {schema.props &&
-                schema.props.length > 0 &&
-                schema.props.map((prop) => (
-                  <SchemaUIProperty
-                    key={prop.name}
-                    name={prop.name}
-                    $type={prop.$type}
-                    overrides={{ required: prop.required }}
-                  />
-                ))}
               <SchemaUIContent {...item} />
             </TabsContent>
           ))}

--- a/packages/openapi/src/ui/schema/index.tsx
+++ b/packages/openapi/src/ui/schema/index.tsx
@@ -43,11 +43,6 @@ export type SchemaData = FieldBase &
           name: string;
           $type: string;
         }[];
-        props: {
-          name: string;
-          $type: string;
-          required: boolean;
-        }[];
       }
   );
 
@@ -213,7 +208,6 @@ function generateSchemaUI({
       const out: SchemaData = {
         type: 'or',
         items: [],
-        props: [],
         ...base(schema),
       };
       refs[id] = out;
@@ -238,30 +232,23 @@ function generateSchemaUI({
       const out: SchemaData = {
         type: 'or',
         items: [],
-        props: [],
         ...base(schema),
       };
       refs[id] = out;
 
       for (const item of schema.oneOf) {
-        const $type = getSchemaId(item);
+        if (typeof item !== 'object') continue;
+        const key = `${id}_extends:${getSchemaId(item)}`;
+        const extended = {
+          ...schema,
+          ...item,
+        };
 
-        scanRefs($type, item);
+        scanRefs(key, extended);
         out.items.push({
-          name: schemaToString(item, ctx.schema, FormatFlags.UseAlias),
-          $type,
+          $type: key,
+          name: schemaToString(extended, ctx.schema, FormatFlags.UseAlias),
         });
-      }
-      if (schema.properties) {
-        for (const [key, prop] of Object.entries(schema.properties)) {
-          const $type = getSchemaId(prop);
-          scanRefs($type, prop);
-          out.props.push({
-            $type,
-            name: key,
-            required: schema.required?.includes(key) ?? false,
-          });
-        }
       }
       return;
     }


### PR DESCRIPTION
## Summary

**Enhancement**: Added support for rendering all schema properties inside `oneOf` types in `SchemaUIContent`.
- This ensures that all relevant schema fields are displayed for `oneOf` types instead of just the selected variant.

## Motivation

Previously, fields of type `oneOf` simply ignored the rest of the properties, resulting in incomplete documentation.
- This update makes the schema rendering behavior consistent with what is supported on [buildwithfern.com](https://buildwithfern.com/) 
<img width="552" height="649" alt="image" src="https://github.com/user-attachments/assets/32c39af1-c893-4d21-9b8c-7c297b78dfb4" />


## Implementation

- Improved logic in the `SchemaUIContent` component to iterate and render all properties of `oneOf` types.
- Updated the `SchemaData` type for better tracking of required properties.
- Inline code comments added for key areas handling `oneOf`.

## Before & After

**Before**: Only the main property inside `oneOf` was shown.
**After**: All properties (including required status) rendered, better representing the schema.

See attached screenshots for visual comparison:
<img width="590" height="592" alt="image" src="https://github.com/user-attachments/assets/fd9c07e0-685f-461e-908a-e017de8be8d5" />
<img width="654" height="822" alt="image" src="https://github.com/user-attachments/assets/4b3ef367-2a47-4761-8123-36e2c8d285c9" />
