### PR TITLE
fix: make viewTop assignment with optional chaining

### DIFF
--- a/packages/core/src/toc.tsx
+++ b/packages/core/src/toc.tsx
@@ -163,7 +163,8 @@ function useAnchorObserver(watch: string[], single: boolean): string[] {
     }
 
     if (state.visible.size === 0) {
-      const viewTop = entries[0].rootBounds!.top;
+      const viewTop =
+        entries.length > 0 ? (entries[0]?.rootBounds?.top ?? 0) : 0;
       let fallback: Element | undefined;
       let min = -1;
 


### PR DESCRIPTION
in a special use case, i've got this error: Cannot read properties of null (reading 'top')
so i've added optional chaining for viewTop