### PR TITLE
feat: cancle search by twice press hotkey

### DIFF
--- a/packages/ui/src/contexts/search.tsx
+++ b/packages/ui/src/contexts/search.tsx
@@ -118,7 +118,7 @@ export function SearchProvider({
         typeof v.key === 'string' ? e.key === v.key : v.key(e),
       )
     ) {
-      setIsOpen(true);
+      setIsOpen((open) => !open);
       e.preventDefault();
     }
   });


### PR DESCRIPTION
I'm used to double-clicking a shortcut to close the search modal, but When using Fumadocs,  I noticed this isn't work.

I know we can already use the `Esc` key to close it, but I think double-clicking as a way to close is also a reasonable habit in this scenario.

If you disagree, feel free to close this PR.