### PR TITLE
fix(mdx): handle picocolors ESM/CJS interop for Turbopack

### DIFF
--- a/packages/mdx/src/utils/validation.ts
+++ b/packages/mdx/src/utils/validation.ts
@@ -15,7 +15,11 @@ export class ValidationError extends Error {
   }
 
   async toStringFormatted() {
-    const picocolors = await import('picocolors');
+    // Handle ESM/CJS interop: picocolors is a CJS module that exports via
+    // module.exports = createColors(). When dynamically imported in ESM context
+    // (e.g., Next.js 16 Turbopack), the exports are wrapped under .default
+    const picocolorsModule = await import('picocolors');
+    const picocolors = picocolorsModule.default ?? picocolorsModule;
 
     return [
       picocolors.bold(`[MDX] ${this.title}:`),


### PR DESCRIPTION
## Summary

Fixes `TypeError: picocolors.bold is not a function` when using fumadocs-mdx with Next.js 16 + Turbopack.

## Fix

```typescript
// Before
const picocolors = await import('picocolors');

// After
const picocolorsModule = await import('picocolors');
const picocolors = picocolorsModule.default ?? picocolorsModule;
```

## Location

File: `packages/mdx/src/utils/validation.ts`  
Method: `ValidationError.toStringFormatted()` (line ~17)


## Why

`picocolors` is CommonJS (`module.exports = createColors()`). Turbopack's ESM handling wraps CJS exports under `.default`:

- `(await import('picocolors')).bold` → ❌ undefined
- `(await import('picocolors')).default.bold` → ✅ works

The nullish coalescing handles both Webpack (no `.default`) and Turbopack (`.default`).

## Testing

- ✅ Applied fix via pnpm patch, verified `/docs` renders (HTTP 200)
- ✅ Tested with `next dev` (Turbopack) and `next dev --webpack`
- ✅ Confirmed MDX validation errors still format correctly when triggered

## Reproduction

1. Create Next.js 16 app with fumadocs-mdx
2. Run `pnpm dev` (Turbopack is default)
3. Navigate to any docs page
4. App crashes with `TypeError: picocolors.bold is not a function`