### PR TITLE
Update ESM requirements for Next.js configuration

### DIFF
--- a/apps/docs/content/docs/mdx/(integrations)/next.mdx
+++ b/apps/docs/content/docs/mdx/(integrations)/next.mdx
@@ -48,14 +48,12 @@ const withMDX = createMDX({
 export default withMDX(config);
 ```
 
-<Callout title="ESM Only" type='warn' className="mt-4">
-Since **Fumadocs is ESM-only**, the Next.js configuration must be an **ES Module**.
+<Callout title="ESM Only" type='warn'>
 
-**`next.config.mjs` is recommended**, as it is always treated as ESM and avoids ambiguity.
+Fumadocs MDX is ESM-only, it's recommended to use `next.config.mjs` for accurate ESM resolution.
 
-You may also use **`next.config.mts`**, but it is supported **only on Node.js v22.18.0 or later**.
+For TypeScript config file, it requires Native Node.js TypeScript Resolver, you can see [Next.js docs](https://nextjs.org/docs/app/api-reference/config/typescript#using-nodejs-native-typescript-resolver-for-nextconfigts) for details.
 
-`next.config.js` or `next.config.ts` can be used when configured as ESM (for example via `"type": "module"` in `package.json`).
 </Callout>
 
 <include>.shared.mdx</include>


### PR DESCRIPTION
Clarified the requirement for Next.js config to be ESM and provided file recommendations.

**Resources:**
- https://github.com/vercel/next.js/pull/83556
-  <img width="906" height="350" alt="{E892D6B4-BD20-49C0-B3A6-D1ED07017862}" src="https://github.com/user-attachments/assets/83e2ce12-f6e7-478f-9b32-61747f90f0ed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Next.js integration guidance: the ESM-only note now provides a multi-line explanation, recommends using an ES Module-based Next.js configuration, and adds guidance about using a native Node.js TypeScript resolver with a link to Next.js docs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->