### PR TITLE
docs: fix callout content margin inside feedback

### DIFF
--- a/apps/docs/components/feedback/client.tsx
+++ b/apps/docs/components/feedback/client.tsx
@@ -259,7 +259,9 @@ export function FeedbackBlock({
           Feedback
         </PopoverTrigger>
 
-        {children}
+        <div className="[.prose-no-margin_&]:prose-no-margin">
+          {children}
+        </div>
       </div>
 
       <PopoverContent className="min-w-[300px]">


### PR DESCRIPTION
## Summary

Fix quote/callout content margin inside `<Feedback>` as can been seen on https://www.fumadocs.dev/docs/headless/search/trieve:

<table>
<tr>
 <td>Before
 <td><img width="857" height="280" alt="Screenshot 2026-01-17 at 5 39 06 PM" src="https://github.com/user-attachments/assets/e457547b-cfcc-4cc6-8eeb-76740a6e27fe" />
<tr>
 <td>After
 <td><img width="862" height="257" alt="Screenshot 2026-01-17 at 5 39 15 PM" src="https://github.com/user-attachments/assets/120b4096-62e6-46f8-a469-3b9c90318ed4" />
</table>

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined feedback block styling in documentation pages to improve visual consistency and ensure proper spacing alignment within prose content areas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->