### PR TITLE
fix(openapi): ensure getSchema uses cached schemas

### DIFF
--- a/.changeset/sunny-pots-obey.md
+++ b/.changeset/sunny-pots-obey.md
@@ -1,0 +1,5 @@
+---
+"fumadocs-openapi": minor
+---
+
+Fixed a performance issue where getSchema() would bypass the internal cache and re-parse the OpenAPI spec on every call. This was caused by calling the internal getSchemas() function instead of the cached method.

--- a/packages/openapi/src/server/create.tsx
+++ b/packages/openapi/src/server/create.tsx
@@ -61,7 +61,7 @@ export function createOpenAPI(options: OpenAPIOptions = {}): OpenAPIServer {
     options,
     createProxy,
     async getSchema(document) {
-      const schemas = await getSchemas();
+      const schemas = await this.getSchemas();
       if (document in schemas) return schemas[document];
 
       console.warn(


### PR DESCRIPTION
Fixed a performance issue where `getSchema()` would bypass the internal cache and re-parse the OpenAPI spec on every call. This was caused by calling the internal `getSchemas()` function instead of the cached method.

## Summary

Problem:
When using `createAPIPage()` with large OpenAPI specs (e.g., 1.9MB with 500+ endpoints), every page render takes 10+ seconds in dev mode, even on subsequent requests. This is because the OpenAPI spec is being re-parsed on every request instead of being cached.

Root Cause
In `packages/openapi/src/server/create.tsx`, the `getSchema()` method calls the internal `getSchemas()` function directly, bypassing the caching mechanism:

```typescript
// Current code (buggy):
async function getSchemas() {
  // This function ALWAYS calls processDocument() - no caching
  const out = {};
  if (Array.isArray(input)) {
    await Promise.all(input.map(async (item) => {
      out[item] = await processDocument(item);  // ❌ Called every time
    }));
  }
  // ...
  return out;
}

return {
  async getSchema(document) {
    const schemas = await getSchemas();  // ❌ Calls internal function, not cached method
    if (document in schemas) return schemas[document];
    // ...
  },
  async getSchemas() {
    if (disableCache) return getSchemas();
    return schemas ??= getSchemas();  // ✅ Cache exists here, but getSchema() doesn't use it
  }
};
```

The caching logic (`schemas ??= getSchemas()`) only exists in the exported `getSchemas()` method. However, `getSchema()` calls the internal `getSchemas()` function, which re-parses the spec every time using `processDocument()`.

Solution
Change `getSchema()` to call `this.getSchemas()` (the cached method) instead of the internal function:

```diff
  async getSchema(document) {
-   const schemas = await getSchemas();
+   const schemas = await this.getSchemas();
    if (document in schemas) return schemas[document];
    // ...
  },
```

Performance Impact:

- First render (cold cache): ~11 seconds (both before and after)
- Subsequent renders (before fix): ~11 seconds (re-parsing on every request)
- Subsequent renders (after fix): ~350ms (reading from cache)
- Result: ~30x speed improvement for subsequent renders in development mode.

How to Reproduce:

1. Create an OpenAPI spec with 500+ endpoints (~1.9MB)
2. Use generateFiles() to create MDX pages
3. Run next dev
4. Navigate to any API page
5. Refresh the page multiple times
6. Observe that each render takes 10+ seconds

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema retrieval performance in fumadocs-openapi by fixing a regression that caused unnecessary re-parsing of OpenAPI specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->