### PR TITLE
fix: break long words in openapi examples

### DIFF
--- a/.changeset/chubby-aliens-allow.md
+++ b/.changeset/chubby-aliens-allow.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-openapi': patch
+---
+
+Break long words in openapi examples

--- a/packages/openapi/src/ui/schema/index.tsx
+++ b/packages/openapi/src/ui/schema/index.tsx
@@ -95,9 +95,9 @@ export function generateSchemaUI(
 
     function field(key: string, value: ReactNode) {
       return (
-        <div className="bg-fd-secondary border rounded-lg text-xs p-1.5 shadow-md">
+        <div className="bg-fd-secondary border rounded-lg text-xs p-1.5 shadow-md max-w-full">
           <span className="font-medium me-2">{key}</span>
-          <code className="text-fd-muted-foreground">{value}</code>
+          <code className="text-fd-muted-foreground wrap-break-word">{value}</code>
         </div>
       );
     }

--- a/packages/openapi/test/schema-ui.test.ts
+++ b/packages/openapi/test/schema-ui.test.ts
@@ -131,7 +131,7 @@ test('test', async () => {
     ",
           "infoTags": [
             <div
-              className="bg-fd-secondary border rounded-lg text-xs p-1.5 shadow-md"
+              className="bg-fd-secondary border rounded-lg text-xs p-1.5 shadow-md max-w-full"
             >
               <span
                 className="font-medium me-2"
@@ -139,7 +139,7 @@ test('test', async () => {
                 Value in
               </span>
               <code
-                className="text-fd-muted-foreground"
+                className="text-fd-muted-foreground wrap-break-word"
               >
                 "NOT_FOUND" | "FORBIDDEN" | "USAGE_EXCEEDED" | "RATE_LIMITED" | "UNAUTHORIZED" | "DISABLED" | "INSUFFICIENT_PERMISSIONS"
               </code>


### PR DESCRIPTION
## Summary
I have a long example parameter string in my docs and it was overflowing from the page and covered by the sticky sidebar. This was reported by users to be a bug, so I made a hacky CSS workaround for my project. It would be nice if this were fixed in fumadocs though, so I made this PR.

Working demo without this fix: https://codesandbox.io/p/github/ndri/fumadocs-overflow-bug/main

Demo repo: https://github.com/ndri/fumadocs-overflow-bug

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots
Before this commit:
<img width="1440" height="810" alt="Screen Shot 2026-01-28 at 16 14 34" src="https://github.com/user-attachments/assets/dd125cfd-c3b8-48c5-b0fa-592be9ddd740" />

After this commit:
<img width="1440" height="810" alt="Screen Shot 2026-01-28 at 16 13 41" src="https://github.com/user-attachments/assets/43db292b-3bd1-4379-bc75-8d04c737d514" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout issues caused by long words in OpenAPI schema examples. Long content and values will now wrap cleanly within code blocks and field displays, preventing layout overflow while maintaining consistent, readable formatting across all example displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->