### PR TITLE
fix(openapi): sync example dropdown with code examples immediately

### DIFF
--- a/examples/content-collections/tsconfig.json
+++ b/examples/content-collections/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ESNext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,11 +17,15 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "paths": {
-      "@/*": ["./*"],
-      "content-collections": ["./.content-collections/generated"]
+      "@/*": [
+        "./*"
+      ],
+      "content-collections": [
+        "./.content-collections/generated"
+      ]
     },
     "plugins": [
       {
@@ -25,6 +33,14 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/examples/remote-mdx/tsconfig.json
+++ b/examples/remote-mdx/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ESNext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,10 +17,12 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     },
     "plugins": [
       {
@@ -24,6 +30,15 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "./scripts/**/*.mjs"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "./scripts/**/*.mjs",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/create-app/template/+next+fuma-docs-mdx/app/docs/[[...slug]]/page.tsx
+++ b/packages/create-app/template/+next+fuma-docs-mdx/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { getMDXComponents } from '@/mdx-components';
 import type { Metadata } from 'next';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { LLMCopyButton, ViewOptions } from '@/components/ai/page-actions';
+import { gitConfig } from '@/lib/layout.shared';
 
 export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   const params = await props.params;
@@ -12,11 +13,6 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   if (!page) notFound();
 
   const MDX = page.data.body;
-  const gitConfig = {
-    user: 'username',
-    repo: 'repo',
-    branch: 'main',
-  };
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
@@ -27,7 +23,7 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
         <ViewOptions
           markdownUrl={`${page.url}.mdx`}
           // update it to match your repo
-          githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/docs/content/docs/${page.path}`}
+          githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
         />
       </div>
       <DocsBody>

--- a/packages/create-app/template/+next+fuma-docs-mdx/components/ai/page-actions.tsx
+++ b/packages/create-app/template/+next+fuma-docs-mdx/components/ai/page-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useMemo, useState } from 'react';
-import { Check, ChevronDown, Copy, ExternalLinkIcon, MessageCircleIcon } from 'lucide-react';
+import { Check, ChevronDown, Copy, ExternalLinkIcon } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useCopyButton } from 'fumadocs-ui/utils/use-copy-button';
 import { buttonVariants } from 'fumadocs-ui/components/ui/button';
@@ -187,11 +187,21 @@ export function ViewOptions({
         ),
       },
       {
-        title: 'Open in T3 Chat',
-        href: `https://t3.chat/new?${new URLSearchParams({
-          q,
+        title: 'Open in Cursor',
+        icon: (
+          <svg
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>Cursor</title>
+            <path d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23" />
+          </svg>
+        ),
+        href: `https://cursor.com/link/prompt?${new URLSearchParams({
+          text: q,
         })}`,
-        icon: <MessageCircleIcon />,
       },
     ];
   }, [githubUrl, markdownUrl]);

--- a/packages/create-app/template/+next+fuma-docs-mdx/lib/layout.shared.tsx
+++ b/packages/create-app/template/+next+fuma-docs-mdx/lib/layout.shared.tsx
@@ -1,9 +1,17 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 
+// fill this with your actual GitHub info, for example:
+export const gitConfig = {
+  user: 'fuma-nama',
+  repo: 'fumadocs',
+  branch: 'main',
+};
+
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
       title: 'My App',
     },
+    githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };
 }

--- a/packages/openapi/src/ui/operation/usage-tabs/client.tsx
+++ b/packages/openapi/src/ui/operation/usage-tabs/client.tsx
@@ -154,7 +154,12 @@ export function UsageTab(sample: CodeUsageGenerator) {
   }, [addListener, removeListener]);
 
   const code = useMemo(() => {
-    if (!sample.source || !data) return;
+    // Look up the currently selected example's data directly to ensure immediate sync
+    // on selection change. The data state may lag by one render due to useEffect timing.
+    const selectedExample = examples.find((example) => example.id === selectedExampleId);
+    const currentData = selectedExample?.encoded ?? data;
+
+    if (!sample.source || !currentData) return;
     if (typeof sample.source === 'string') return sample.source;
 
     return sample.source(
@@ -163,15 +168,15 @@ export function UsageTab(sample: CodeUsageGenerator) {
           server ? resolveServerUrl(server.url, server.variables) : '/',
           typeof window !== 'undefined' ? window.location.origin : 'https://loading',
         ),
-        resolveRequestData(route, data),
+        resolveRequestData(route, currentData),
       ),
-      data,
+      currentData,
       {
         server: sample.serverContext,
         mediaAdapters,
       },
     );
-  }, [mediaAdapters, sample, server, route, data]);
+  }, [mediaAdapters, sample, server, route, data, selectedExampleId, examples]);
 
   if (!code || !sample) return null;
 


### PR DESCRIPTION
## Summary

Fixes #2982

When switching between examples in the dropdown, the code examples now update immediately instead of showing the previous selection's data.

## Problem

The `UsageTab` component's `data` state was being updated via a `useEffect` listener, which runs after render. This caused a one-render delay where the code block would show the **previous** example's data before updating to the current selection.

## Solution

Modified the `code` useMemo in `UsageTab` to look up the selected example's `encoded` data directly using `selectedExampleId`, rather than relying solely on the `data` state which may be stale for one render cycle.

```tsx
// Before: used data state which could be one render behind
const code = useMemo(() => {
  if (!sample.source || !data) return;
  // ...
}, [mediaAdapters, sample, server, route, data]);

// After: look up current example directly, ensuring immediate sync
const code = useMemo(() => {
  const selectedExample = examples.find((example) => example.id === selectedExampleId);
  const currentData = selectedExample?.encoded ?? data;
  
  if (!sample.source || !currentData) return;
  // ...
}, [mediaAdapters, sample, server, route, data, selectedExampleId, examples]);
```

This ensures that when `selectedExampleId` changes, the code is immediately computed with the correct example's data, without waiting for the useEffect listener to update the state.

## Testing

- Build passes: `pnpm --filter fumadocs-openapi... build`
- Lint passes: `pnpm --filter fumadocs-openapi lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open in Cursor" action for quick documentation access directly in the Cursor editor.

* **Improvements**
  * Enhanced example selection synchronization for more responsive switching between documentation examples.

* **Configuration**
  * Updated TypeScript and JSX configuration settings for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->