### PR TITLE
fix(docs): add missing warn type to Callout example

### DIFF
--- a/apps/docs/content/docs/(framework)/markdown/index.mdx
+++ b/apps/docs/content/docs/(framework)/markdown/index.mdx
@@ -150,7 +150,9 @@ Useful for adding tips/warnings, it is included by default. You can specify the 
 ```mdx
 <Callout>Hello World</Callout>
 
-<Callout title="Title">Hello World</Callout>
+<Callout title="Title" type="warn">
+  Hello World
+</Callout>
 
 <Callout title="Title" type="error">
   Hello World


### PR DESCRIPTION
## Summary

- Update [Callout example](https://www.fumadocs.dev/docs/markdown#callouts) to include `type="warn"`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Callout component example in the documentation to demonstrate explicit type parameter specification and improved content structure patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->