### PR TITLE
Docs: add community integration Typesense search

### DIFF
--- a/apps/docs/content/docs/(framework)/search/index.mdx
+++ b/apps/docs/content/docs/(framework)/search/index.mdx
@@ -18,3 +18,4 @@ You can choose & configure the search client according to your search engine, it
 A list of integrations maintained by community.
 
 - [Trieve Search](/docs/headless/search/trieve)
+- [Typesense Search](/docs/headless/search/typesense)

--- a/apps/docs/content/docs/(framework)/search/typesense.mdx
+++ b/apps/docs/content/docs/(framework)/search/typesense.mdx
@@ -1,0 +1,118 @@
+---
+title: Typesense
+description: Using Typesense with Fumadocs UI.
+---
+
+> This is a community-maintained integration.
+
+## Setup
+
+1. Integrate [Typesense Search](/docs/headless/search/typesense).
+
+2. Create a search dialog component.
+
+   ```tsx title="components/search.tsx"
+   'use client';
+   import {
+     SearchDialog,
+     SearchDialogClose,
+     SearchDialogContent,
+     SearchDialogFooter,
+     SearchDialogHeader,
+     SearchDialogIcon,
+     SearchDialogInput,
+     SearchDialogList,
+     SearchDialogOverlay,
+     type SharedProps,
+   } from 'fumadocs-ui/components/dialog/search';
+   import { useI18n } from 'fumadocs-ui/contexts/i18n';
+   import { Client } from 'typesense';
+   import { useTypesenseSearch } from 'typesense-fumadocs-adapter/client';
+
+   const client = new Client({
+     nodes: [{ url: 'YOUR_TYPESENSE_SERVER_URL' }],
+     apiKey: 'YOUR_TYPESENSE_SEARCH_ONLY_API_KEY',
+   });
+
+   export default function TypesenseSearchDialog(props: SharedProps) {
+     const { locale } = useI18n(); // optional
+     const { search, setSearch, query } = useTypesenseSearch({
+       typesenseCollectionName: `YOUR_TYPESENSE_COLLECTION_NAME`,
+       locale,
+       legacy: false, // optional, set to true for fumadocs-ui version < 16.6.0
+       client,
+     });
+
+     return (
+       <SearchDialog
+         search={search}
+         onSearchChange={setSearch}
+         isLoading={query.isLoading}
+         {...props}
+       >
+         <SearchDialogOverlay />
+         <SearchDialogContent>
+           <SearchDialogHeader>
+             <SearchDialogIcon />
+             <SearchDialogInput />
+             <SearchDialogClose />
+           </SearchDialogHeader>
+           <SearchDialogList items={query.data !== 'empty' ? query.data : null} />
+           <SearchDialogFooter>
+             <div className="w-full text-right text-xs text-fd-muted-foreground">
+               <a href="https://typesense.org" rel="noreferrer noopener" target="_blank">
+                 Search powered by Typesense
+               </a>
+             </div>
+           </SearchDialogFooter>
+         </SearchDialogContent>
+       </SearchDialog>
+     );
+   }
+   ```
+
+<include>.shared.mdx</include>
+
+### Tag Filter
+
+Optionally, you can add UI for filtering results by tags. Configure [Tag Filter](/docs/headless/search/typesense#tag-filter) on search server and add the following:
+
+```tsx
+'use client';
+
+import {
+  SearchDialog,
+  SearchDialogContent,
+  SearchDialogFooter,
+  SearchDialogOverlay,
+  type SharedProps,
+  TagsList,
+  TagsListItem,
+} from 'fumadocs-ui/components/dialog/search';
+import { useState } from 'react';
+import { useTypesenseSearch } from 'typesense-fumadocs-adapter/client';
+
+export default function TypesenseSearchDialog(props: SharedProps) {
+  // [!code ++]
+  const [tag, setTag] = useState<string | undefined>();
+  const { search, setSearch, query } = useTypesenseSearch({
+    tag, // [!code ++]
+    // other options...
+  });
+
+  return (
+    <SearchDialog>
+      <SearchDialogOverlay />
+      <SearchDialogContent>
+        ...
+        <SearchDialogFooter className="flex flex-row">
+          {/* [!code ++:3] */}
+          <TagsList tag={tag} onTagChange={setTag}>
+            <TagsListItem value="my-value">My Value</TagsListItem>
+          </TagsList>
+        </SearchDialogFooter>
+      </SearchDialogContent>
+    </SearchDialog>
+  );
+}
+```

--- a/apps/docs/content/docs/headless/search/typesense.mdx
+++ b/apps/docs/content/docs/headless/search/typesense.mdx
@@ -1,0 +1,215 @@
+---
+title: Typesense Search
+description: Integrate Typesense Search with Fumadocs
+---
+
+> This is a community-maintained integration.
+
+## Setup
+
+### Install Dependencies
+
+```package-install
+typesense typesense-fumadocs-adapter
+```
+
+### Start Typesense Server
+
+You can either self-host the Typesense server or use their cloud service. Follow their [getting started guide](https://typesense.org/docs/guide/install-typesense.html) to set up your server and obtain the API key and server URL.
+
+### Sync Dataset
+
+Export the search indexes by pre-rendering a static route.
+
+```ts title="lib/export-search-indexes.ts"
+import { source } from '@/lib/source';
+import { findPath } from 'fumadocs-core/page-tree';
+import type { DocumentRecord } from 'typesense-fumadocs-adapter';
+
+export async function exportSearchIndexes() {
+  const results: DocumentRecord[] = [];
+
+  function isBreadcrumbItem(item: unknown): item is string {
+    return typeof item === 'string' && item.length > 0;
+  }
+
+  for (const page of source.getPages()) {
+    let breadcrumbs: string[] | undefined;
+    const pageTree = source.getPageTree(page.locale);
+    const path = findPath(
+      pageTree.children,
+      (node) => node.type === 'page' && node.url === page.url,
+    );
+
+    if (path) {
+      breadcrumbs = [];
+      path.pop();
+      if (isBreadcrumbItem(pageTree.name)) {
+        breadcrumbs.push(pageTree.name);
+      }
+      for (const segment of path) {
+        if (!isBreadcrumbItem(segment.name)) continue;
+        breadcrumbs.push(segment.name);
+      }
+    }
+
+    results.push({
+      _id: page.url,
+      structured: page.data.structuredData,
+      url: page.url,
+      title: page.data.title,
+      description: page.data.description,
+      breadcrumbs,
+      locale: page.locale,
+    });
+  }
+
+  return results;
+}
+```
+
+<include>.static-route-example.mdx</include>
+
+Create a script to sync search indexes:
+
+```ts title="scripts/sync-content.ts"
+import * as fs from 'node:fs';
+import { sync, DocumentRecord } from 'typesense-fumadocs-adapter';
+import { Client } from 'typesense';
+
+// the path of pre-rendered `static.json`, choose one according to your React framework
+const filePath = {
+  next: '.next/server/app/static.json.body',
+  'tanstack-start': '.output/public/static.json',
+  'react-router': 'build/client/static.json',
+  waku: 'dist/public/static.json',
+}['next'];
+
+const content = fs.readFileSync(filePath);
+
+const records = JSON.parse(content.toString()) as DocumentRecord[];
+
+const client = new Client({
+  nodes: [{ url: 'YOUR_TYPESENSE_SERVER_URL' }],
+  apiKey: 'YOUR_TYPESENSE_API_KEY_WITH_WRITE_ACCESS',
+  connectionTimeoutSeconds: 60 * 15,
+});
+
+// update the collection settings and sync search indexes
+void sync(client, {
+  typesenseCollectionName: 'YOUR_COLLECTION_NAME',
+  documents: records,
+});
+```
+
+Make sure to run the script after build:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "... && bun scripts/sync-content.ts"
+  }
+}
+```
+
+> You can also integrate it with your CI/CD pipeline.
+
+### Search UI
+
+To implement the search UI, you can either:
+
+- Use [Fumadocs UI search dialog](/docs/search/typesense).
+- Build your own search UI with the Typesense search client hook.
+
+  ```ts
+  import { Client } from 'typesense';
+  import { useTypesenseSearch } from 'typesense-fumadocs-adapter/client';
+
+  const client = new Client({
+    nodes: [{ url: 'YOUR_TYPESENSE_SERVER_URL' }],
+    apiKey: 'YOUR_TYPESENSE_SEARCH_ONLY_API_KEY',
+  });
+
+  const { search, setSearch, query } = useTypesenseSearch({
+    typesenseCollectionName: 'YOUR_COLLECTION_NAME',
+    client,
+  });
+  ```
+
+## Options
+
+### Tag Filter
+
+To configure tag filtering, add a `tag` value to indexes.
+
+```ts title="lib/export-search-indexes.ts"
+import { source } from '@/lib/source';
+import type { DocumentRecord } from 'typesense-fumadocs-adapter';
+
+export async function exportSearchIndexes() {
+  const results: DocumentRecord[] = [];
+
+  for (const page of source.getPages()) {
+    results.push({
+      // other fields...
+      // [!code ++]
+      tag: '<your value>',
+    });
+  }
+
+  return results;
+}
+```
+
+And update your search client:
+
+- **Fumadocs UI**: Enable [Tag Filter](/docs/search/typesense#tag-filter) on Search UI.
+- **Search Client**: You can add the tag filter like:
+
+  ```ts
+  import { useTypesenseSearch } from 'typesense-fumadocs-adapter/client';
+  const { search, setSearch, query } = useTypesenseSearch({
+    tag: '<your tag value>',
+    // ...
+  });
+  ```
+
+### Internationalization (i18n)
+
+To support internationalization, make sure to add a `locale` value to each document.
+
+```ts title="lib/export-search-indexes.ts"
+import { source } from '@/lib/source';
+import { findPath } from 'fumadocs-core/page-tree';
+import type { DocumentRecord } from 'typesense-fumadocs-adapter';
+
+export async function exportSearchIndexes() {
+  const results: DocumentRecord[] = [];
+
+  for (const page of source.getPages()) {
+    results.push({
+      // other fields...
+      // [!code ++]
+      locale: page.locale,
+    });
+  }
+
+  return results;
+}
+```
+
+And update your search client:
+
+```ts
+import { useI18n } from 'fumadocs-ui/contexts/i18n';
+import { useTypesenseSearch } from 'typesense-fumadocs-adapter/client';
+
+const { locale } = useI18n();
+const { search, setSearch, query } = useTypesenseSearch({
+  // [!code ++]
+  locale,
+  // other fields...
+});
+```
+
+Under the hood, Typesense will create separate collections for each locale. The collection name is appended with the `_{locale}` suffix (e.g., `YOUR_COLLECTION_NAME_en`, `YOUR_COLLECTION_NAME_fr`).


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

This PR adds two new documentation pages explaining how to integrate Typesense search with Fumadocs using the [`typesense-fumadocs-adapter`](https://github.com/typesense/typesense-fumadocs-adapter):
- `/docs/search/typesense`
- `/docs/headless/search/typesense`

I recently developed this adapter and have verified the integration works seamlessly with Fumadocs 🚀

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): Documentation

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Typesense search integration documentation with detailed setup instructions and configuration guidance for Fumadocs.
  * Included code examples demonstrating search dialog setup, client initialization, and tag-based filtering capabilities.
  * Added Typesense to the community integrations list for improved discoverability and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->