### PR TITLE
fix(ui): point sidebar chevron left when collapsed in RTL

### DIFF
--- a/.changeset/fix-rtl-sidebar-chevron.md
+++ b/.changeset/fix-rtl-sidebar-chevron.md
@@ -1,0 +1,11 @@
+---
+'fumadocs-ui': patch
+'@fumadocs/base-ui': patch
+---
+
+fix: reverse sidebar chevron direction for RTL layouts
+
+In RTL mode, the `ChevronDown` icon in collapsed sidebar folders was
+incorrectly pointing to the right (via `-rotate-90`). Added `rtl:rotate-90`
+so the icon points to the left when the folder is collapsed, matching
+the expected RTL reading direction.

--- a/packages/base-ui/src/components/sidebar/base.tsx
+++ b/packages/base-ui/src/components/sidebar/base.tsx
@@ -320,7 +320,7 @@ export function SidebarFolderTrigger({ children, ...props }: CollapsibleTriggerP
         {children}
         <ChevronDown
           data-icon
-          className={cn('ms-auto transition-transform', !open && '-rotate-90')}
+          className={cn('ms-auto transition-transform', !open && '-rotate-90 rtl:rotate-90')}
         />
       </CollapsibleTrigger>
     );
@@ -363,7 +363,7 @@ export function SidebarFolderLink({
       {collapsible && (
         <ChevronDown
           data-icon
-          className={cn('ms-auto transition-transform', !open && '-rotate-90')}
+          className={cn('ms-auto transition-transform', !open && '-rotate-90 rtl:rotate-90')}
         />
       )}
     </Link>

--- a/packages/radix-ui/src/components/sidebar/base.tsx
+++ b/packages/radix-ui/src/components/sidebar/base.tsx
@@ -310,7 +310,7 @@ export function SidebarFolderTrigger({ children, ...props }: CollapsibleTriggerP
         {children}
         <ChevronDown
           data-icon
-          className={cn('ms-auto transition-transform', !open && '-rotate-90')}
+          className={cn('ms-auto transition-transform', !open && '-rotate-90 rtl:rotate-90')}
         />
       </CollapsibleTrigger>
     );
@@ -353,7 +353,7 @@ export function SidebarFolderLink({
       {collapsible && (
         <ChevronDown
           data-icon
-          className={cn('ms-auto transition-transform', !open && '-rotate-90')}
+          className={cn('ms-auto transition-transform', !open && '-rotate-90 rtl:rotate-90')}
         />
       )}
     </Link>


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

  In RTL mode, collapsed sidebar folder items show the `ChevronDown` icon
  pointing right (via `-rotate-90`), which is incorrect for RTL reading direction.
  Added `rtl:rotate-90` so the chevron points left when a folder is collapsed in RTL.

  **Before:** collapsed folder chevron → right ❌
  **After:** collapsed folder chevron ← left ✅

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chevron icon rotation in sidebar folder triggers for right-to-left (RTL) layouts. Collapsed folders now correctly display the chevron pointing left, ensuring proper visual alignment with RTL reading direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->