### PR TITLE
fix(ui): use logical CSS properties in Steps component for RTL support

### DIFF
--- a/.changeset/fix-rtl-steps-logical-properties.md
+++ b/.changeset/fix-rtl-steps-logical-properties.md
@@ -1,0 +1,6 @@
+---
+'fumadocs-ui': patch
+'@fumadocs/base-ui': patch
+---
+
+fix: use logical CSS properties in Steps component for RTL support

--- a/packages/base-ui/css/lib/base.css
+++ b/packages/base-ui/css/lib/base.css
@@ -175,7 +175,7 @@
 @utility fd-steps {
   counter-reset: step;
   position: relative;
-  @apply pl-6 ml-2 border-l sm:ml-4 sm:pl-7;
+  @apply ps-6 ms-2 border-s sm:ms-4 sm:ps-7;
 }
 
 @utility fd-step {

--- a/packages/radix-ui/css/lib/base.css
+++ b/packages/radix-ui/css/lib/base.css
@@ -175,7 +175,7 @@
 @utility fd-steps {
   counter-reset: step;
   position: relative;
-  @apply pl-6 ml-2 border-l sm:ml-4 sm:pl-7;
+  @apply ps-6 ms-2 border-s sm:ms-4 sm:ps-7;
 }
 
 @utility fd-step {


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Problem
The `.fd-steps` utility uses physical CSS properties (`pl-6`, `ml-2`, `border-l`, `sm:ml-4`, `sm:pl-7`), which breaks the layout in RTL — the step number circle and vertical border
appear on the wrong side, causing the circle to overlap the heading text.

  ## Solution
  Replace physical properties with their logical equivalents:

  | Before | After |
  |---|---|
  | `pl-6` | `ps-6` |
  | `ml-2` | `ms-2` |
  | `border-l` | `border-s` |
  | `sm:ml-4` | `sm:ms-4` |
  | `sm:pl-7` | `sm:ps-7` |

The `::before` pseudo-element already uses `-start-4` (logical), so no change needed there.

This fix has zero impact on LTR layouts — logical properties behave identically to physical ones in LTR.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Steps component styling to properly support right-to-left (RTL) languages, ensuring consistent layout and spacing regardless of text direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->