### PR TITLE
CLI: Fix layout component registry url

### DIFF
--- a/packages/cli/src/commands/customise.ts
+++ b/packages/cli/src/commands/customise.ts
@@ -48,7 +48,7 @@ export async function customise(client: RegistryClient) {
               label: 'Start from minimal styles',
               hint: 'for those who want to build their own variant from ground up.',
               value: {
-                target: ['fumadocs/ui/layouts/docs-min'],
+                target: ['layouts/docs-min'],
                 replace: [
                   ['fumadocs-ui/layouts/docs', '@/components/layout/docs'],
                   ['fumadocs-ui/layouts/docs/page', '@/components/layout/docs/page'],


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->
Fix error when running `pnpm dlx @fumadocs/cli customize`.

`https://fumadocs.dev/registry/fumadocs/ui/layouts/docs-min.json` was not found.
Using `https://www.fumadocs.dev/registry/layouts/docs-min.json` fixes the issue.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

<img width="1022" height="188" alt="截屏2026-03-10 21 08 16" src="https://github.com/user-attachments/assets/4db41aa1-d839-487e-8813-3c5aef7f3d0a" />


## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the target path reference in the minimal styles customization option to ensure correct source resolution during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->