### PR TITLE
docs: quote pnpm filter glob for zsh compatibility

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -58,7 +58,7 @@ This repository uses Turborepo, so development servers should be started using t
 Before running any app, build all shared packages:
 
 ```bash
-pnpm run build --filter=./packages/*
+pnpm run build --filter='./packages/*'
 ```
 
 Then, start docs site in dev mode.
@@ -92,6 +92,6 @@ You may start with contributing to the docs,
 it is located in `/apps/docs/content/docs`.
 
 To run the docs site in dev mode,
-build the dependencies with `pnpm run build --filter=./packages/*` and run `pnpm run dev --filter=docs` to start the dev server.
+build the dependencies with `pnpm run build --filter='./packages/*'` and run `pnpm run dev --filter=docs` to start the dev server.
 
 You don't need any extra environment variables to run this project.


### PR DESCRIPTION
## Summary
- quote the `./packages/*` filter in the contributing guide
- keep the command semantics unchanged while avoiding zsh glob expansion errors

## Why
`pnpm run build --filter=./packages/*` fails in default zsh with `no matches found` because the shell expands the glob before pnpm receives it.

## Testing
- not run; documentation-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build command examples in the contribution guidelines: the filter argument is now quoted for consistent formatting across documentation. This is a purely stylistic change to examples and does not alter command behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->