### PR TITLE
Add click handler to close mobile TOC popover on anchor click

### DIFF
--- a/packages/base-ui/src/layouts/docs/page/slots/toc.tsx
+++ b/packages/base-ui/src/layouts/docs/page/slots/toc.tsx
@@ -276,8 +276,18 @@ function ProgressCircle({
 }
 
 function PageTOCPopoverContent(props: ComponentProps<'div'>) {
+  const { setOpen } = use(TocPopoverContext)!;
+
   return (
-    <CollapsibleContent data-toc-popover-content="" {...props}>
+    <CollapsibleContent
+      data-toc-popover-content=""
+      {...props}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('a')) {
+          setOpen(false);
+        }
+      }}
+    >
       <div className="flex flex-col px-4 max-h-[50vh] md:px-6">{props.children}</div>
     </CollapsibleContent>
   );

--- a/packages/base-ui/src/layouts/flux/page/slots/toc.tsx
+++ b/packages/base-ui/src/layouts/flux/page/slots/toc.tsx
@@ -247,8 +247,18 @@ function ProgressCircle({
 }
 
 function PageTOCPopoverContent(props: ComponentProps<'div'>) {
+  const { setOpen } = use(TocPopoverContext)!;
+
   return (
-    <CollapsibleContent data-toc-popover-content="" {...props}>
+    <CollapsibleContent
+      data-toc-popover-content=""
+      {...props}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('a')) {
+          setOpen(false);
+        }
+      }}
+    >
       <div className="flex flex-col px-2 max-h-[50vh]">{props.children}</div>
     </CollapsibleContent>
   );

--- a/packages/base-ui/src/layouts/notebook/page/slots/toc.tsx
+++ b/packages/base-ui/src/layouts/notebook/page/slots/toc.tsx
@@ -276,8 +276,18 @@ function ProgressCircle({
 }
 
 function PageTOCPopoverContent(props: ComponentProps<'div'>) {
+  const { setOpen } = use(TocPopoverContext)!;
+
   return (
-    <CollapsibleContent data-toc-popover-content="" {...props}>
+    <CollapsibleContent
+      data-toc-popover-content=""
+      {...props}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('a')) {
+          setOpen(false);
+        }
+      }}
+    >
       <div className="flex flex-col px-4 max-h-[50vh] md:px-6">{props.children}</div>
     </CollapsibleContent>
   );

--- a/packages/radix-ui/src/layouts/docs/page/slots/toc.tsx
+++ b/packages/radix-ui/src/layouts/docs/page/slots/toc.tsx
@@ -276,8 +276,18 @@ function ProgressCircle({
 }
 
 function PageTOCPopoverContent(props: ComponentProps<'div'>) {
+  const { setOpen } = use(TocPopoverContext)!;
+
   return (
-    <CollapsibleContent data-toc-popover-content="" {...props}>
+    <CollapsibleContent
+      data-toc-popover-content=""
+      {...props}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('a')) {
+          setOpen(false);
+        }
+      }}
+    >
       <div className="flex flex-col px-4 max-h-[50vh] md:px-6">{props.children}</div>
     </CollapsibleContent>
   );

--- a/packages/radix-ui/src/layouts/flux/page/slots/toc.tsx
+++ b/packages/radix-ui/src/layouts/flux/page/slots/toc.tsx
@@ -247,8 +247,18 @@ function ProgressCircle({
 }
 
 function PageTOCPopoverContent(props: ComponentProps<'div'>) {
+  const { setOpen } = use(TocPopoverContext)!;
+
   return (
-    <CollapsibleContent data-toc-popover-content="" {...props}>
+    <CollapsibleContent
+      data-toc-popover-content=""
+      {...props}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('a')) {
+          setOpen(false);
+        }
+      }}
+    >
       <div className="flex flex-col px-2 max-h-[50vh]">{props.children}</div>
     </CollapsibleContent>
   );

--- a/packages/radix-ui/src/layouts/notebook/page/slots/toc.tsx
+++ b/packages/radix-ui/src/layouts/notebook/page/slots/toc.tsx
@@ -276,8 +276,18 @@ function ProgressCircle({
 }
 
 function PageTOCPopoverContent(props: ComponentProps<'div'>) {
+  const { setOpen } = use(TocPopoverContext)!;
+
   return (
-    <CollapsibleContent data-toc-popover-content="" {...props}>
+    <CollapsibleContent
+      data-toc-popover-content=""
+      {...props}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('a')) {
+          setOpen(false);
+        }
+      }}
+    >
       <div className="flex flex-col px-4 max-h-[50vh] md:px-6">{props.children}</div>
     </CollapsibleContent>
   );


### PR DESCRIPTION
## Summary
Add a click handler to the Table of Contents (TOC) popover that closes the popover when an anchor link is clicked.

## Related Issues

closes #3143

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Table of contents popovers now automatically close when you click on a navigation link, providing a smoother navigation experience across all layout types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->