### PR TITLE
fix: allow internal link resolver to resolve for "../" links as well

### DIFF
--- a/.changeset/sweet-days-check.md
+++ b/.changeset/sweet-days-check.md
@@ -1,0 +1,5 @@
+---
+"@fumadocs/base-ui": patch
+---
+
+fix: allow internal link resolver to resolve for "../" links

--- a/packages/core/src/source/loader.ts
+++ b/packages/core/src/source/loader.ts
@@ -348,7 +348,7 @@ export function loader(
       const [value, hash] = href.split('#', 2);
       let target;
 
-      if (value.startsWith('./')) {
+      if (value.startsWith('./') || value.startsWith('../')) {
         const path = joinPath(dir, value);
 
         target = indexer.getPage(path, language);

--- a/packages/core/src/source/loader.ts
+++ b/packages/core/src/source/loader.ts
@@ -363,7 +363,7 @@ export function loader(
         };
     },
     resolveHref(href, parent) {
-      if (href.startsWith('./')) {
+      if (href.startsWith('./') || href.startsWith('../')) {
         const target = this.getPageByHref(href, {
           dir: path.dirname(parent.path),
           language: parent.locale,


### PR DESCRIPTION
## Summary
The documentation at https://www.fumadocs.dev/docs/ui/components shows an example of using `createRelativeLink` with the following string: `../../(integrations)/feedback.mdx`

However, this doesn't get resolved by `createResolveLink`, as the function only checks for strings starting with `./`.

Because of this, if you need to link to a page in a different parent directory, you must write it like `./../../(integrations)/feedback.mdx`, making it start with `./`

I think this is unnecessary and the function should handle this for us

This PR changes the function to also resolve hrefs starting with `../`

```
if (href.startsWith('./')) {
```

becomes

```
if (href.startsWith('./') || href.startsWith('../')) {
```

It is a breaking change however, as it may affect users that are using `../` already without it resolving. However I can't think of a use case why a user would do that without it being a mistake, so it may be fine to push as a patch.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parent-directory relative links using "../" now resolve correctly, fixing broken cross-page links.
  * When a matching page is found, any URL fragment (hash) is preserved; unresolved links are left unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->