### PR TITLE
feat(core): add description and sections options to llms.txt config

### DIFF
--- a/.changeset/llms-description-and-sections.md
+++ b/.changeset/llms-description-and-sections.md
@@ -1,0 +1,22 @@
+---
+'fumadocs-core': minor
+---
+
+Add `description` and `sections` options to `LLMsConfig` for customizing `llms.txt` output.
+
+- `description` renders as a blockquote after the H1 title (per the [llms.txt spec](https://llmstxt.org/))
+- `sections` is an array of `{ heading, content, position? }` inserted before or after the page tree
+
+Use cases: site-specific prose like access patterns, license notes, contact info, and the spec-mandated description blockquote.
+
+```ts
+llms(source, {
+  description: 'A knowledge base for humans and AI agents.',
+  sections: [
+    {
+      heading: 'Access patterns',
+      content: '- Send `Accept: text/markdown` to any URL',
+    },
+  ],
+}).index();
+```

--- a/packages/core/src/source/loader/llms.ts
+++ b/packages/core/src/source/loader/llms.ts
@@ -5,10 +5,38 @@ interface Context {
   lang?: string;
 }
 
+export interface LLMsSection {
+  /**
+   * Heading text rendered as `## {heading}`.
+   */
+  heading: string;
+  /**
+   * Raw markdown content rendered under the heading.
+   */
+  content: string;
+  /**
+   * Where the section is inserted relative to the auto-generated page tree.
+   *
+   * @default 'before-index'
+   */
+  position?: 'before-index' | 'after-index';
+}
+
 export interface LLMsConfig {
   TAB?: string;
   renderName?: (item: PageTree.Node | PageTree.Root, ctx: Context) => string;
   renderDescription?: (item: PageTree.Item | PageTree.Folder, ctx: Context) => string;
+  /**
+   * Description blockquote rendered after the H1 title, per the llms.txt
+   * specification (https://llmstxt.org/).
+   */
+  description?: string;
+  /**
+   * Custom H2 sections inserted before or after the auto-generated page tree.
+   * Use for site-specific prose — access patterns, license notes, contact
+   * info, etc.
+   */
+  sections?: LLMsSection[];
 }
 
 export function llms<C extends LoaderConfig>(loader: LoaderOutput<C>, config: LLMsConfig = {}) {
@@ -32,7 +60,13 @@ export function llms<C extends LoaderConfig>(loader: LoaderOutput<C>, config: LL
 
       return String(node.description);
     },
+    description,
+    sections = [],
   } = config;
+
+  function renderSection(section: LLMsSection): string[] {
+    return ['', `## ${section.heading}`, '', section.content.trimEnd()];
+  }
 
   function index(lang?: string): string {
     if (loader._i18n && lang === undefined) {
@@ -45,6 +79,18 @@ export function llms<C extends LoaderConfig>(loader: LoaderOutput<C>, config: LL
     const ctx: Context = { lang };
     out.push(`# ${renderName(pageTree, ctx)}`);
     out.push('');
+
+    if (description) {
+      out.push(`> ${description}`);
+      out.push('');
+    }
+
+    for (const section of sections) {
+      if ((section.position ?? 'before-index') === 'before-index') {
+        out.push(...renderSection(section));
+        out.push('');
+      }
+    }
 
     function item(name: string, description: string, indent: number) {
       const prefix = TAB.repeat(indent);
@@ -81,6 +127,13 @@ export function llms<C extends LoaderConfig>(loader: LoaderOutput<C>, config: LL
     }
 
     for (const child of pageTree.children) onNode(child, 0);
+
+    for (const section of sections) {
+      if (section.position === 'after-index') {
+        out.push(...renderSection(section));
+      }
+    }
+
     return out.join('\n');
   }
 

--- a/packages/core/test/llms.test.ts
+++ b/packages/core/test/llms.test.ts
@@ -1,0 +1,144 @@
+import { expect, test } from 'vitest';
+import { llms, loader } from '@/source';
+import { source } from './fixtures/page-trees/basic';
+
+test('llms: renders H1 title and page index', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+  ).index();
+
+  expect(output).toContain('# Docs');
+  expect(output).toContain('- [Hello](/docs/test)');
+});
+
+test('llms: renders description blockquote after title', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      description: 'A knowledge base for humans and AI agents.',
+    },
+  ).index();
+
+  const lines = output.split('\n');
+  expect(lines[0]).toBe('# Docs');
+  expect(lines[1]).toBe('');
+  expect(lines[2]).toBe('> A knowledge base for humans and AI agents.');
+  expect(lines[3]).toBe('');
+});
+
+test('llms: renders before-index sections between description and index', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      description: 'Short description.',
+      sections: [
+        {
+          heading: 'Access patterns',
+          content: '- Send `Accept: text/markdown` to any URL',
+        },
+      ],
+    },
+  ).index();
+
+  const descIdx = output.indexOf('> Short description.');
+  const sectionIdx = output.indexOf('## Access patterns');
+  const pageIdx = output.indexOf('- [Hello]');
+
+  expect(descIdx).toBeGreaterThan(-1);
+  expect(sectionIdx).toBeGreaterThan(descIdx);
+  expect(pageIdx).toBeGreaterThan(sectionIdx);
+  expect(output).toContain('- Send `Accept: text/markdown` to any URL');
+});
+
+test('llms: before-index is the default section position', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      sections: [{ heading: 'Note', content: 'Body text.' }],
+    },
+  ).index();
+
+  const sectionIdx = output.indexOf('## Note');
+  const pageIdx = output.indexOf('- [Hello]');
+  expect(sectionIdx).toBeGreaterThan(-1);
+  expect(sectionIdx).toBeLessThan(pageIdx);
+});
+
+test('llms: after-index sections render after the page tree', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      sections: [
+        {
+          heading: 'Footer',
+          content: 'See LICENSE.',
+          position: 'after-index',
+        },
+      ],
+    },
+  ).index();
+
+  const pageIdx = output.indexOf('- [Hello]');
+  const footerIdx = output.indexOf('## Footer');
+  expect(footerIdx).toBeGreaterThan(pageIdx);
+  expect(output).toContain('See LICENSE.');
+});
+
+test('llms: multiple sections with mixed positions', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      sections: [
+        { heading: 'Intro', content: 'Intro body.' },
+        {
+          heading: 'License',
+          content: 'MIT.',
+          position: 'after-index',
+        },
+        { heading: 'Before', content: 'Before body.', position: 'before-index' },
+      ],
+    },
+  ).index();
+
+  const introIdx = output.indexOf('## Intro');
+  const beforeIdx = output.indexOf('## Before');
+  const pageIdx = output.indexOf('- [Hello]');
+  const licenseIdx = output.indexOf('## License');
+
+  expect(introIdx).toBeGreaterThan(-1);
+  expect(beforeIdx).toBeGreaterThan(introIdx);
+  expect(pageIdx).toBeGreaterThan(beforeIdx);
+  expect(licenseIdx).toBeGreaterThan(pageIdx);
+});
+
+test('llms: omits description and sections when not provided (back-compat)', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+  ).index();
+
+  expect(output).not.toContain('> ');
+  expect(output).not.toContain('##');
+  expect(output).toContain('# Docs');
+  expect(output).toContain('- [Hello]');
+});


### PR DESCRIPTION
Addresses #3186 (option 1 of 2).

## Summary

Extends `LLMsConfig` with two optional fields for customizing `llms.txt` output:

- **`description`** — blockquote rendered after the H1 title, per the [llms.txt spec](https://llmstxt.org/). Currently omitted by Fumadocs.
- **`sections`** — array of `{ heading, content, position? }` inserted before or after the auto-generated page tree. Use for site-specific prose like access patterns, license notes, contact info.

Both options are optional. Existing consumers of `llms()` see no behavior change.

## Usage

\`\`\`ts
llms(source, {
  description: 'A knowledge base for humans and AI agents.',
  sections: [
    {
      heading: 'Access patterns',
      content: '- Send `Accept: text/markdown` to any URL',
    },
    {
      heading: 'License',
      content: 'MIT.',
      position: 'after-index',
    },
  ],
}).index();
\`\`\`

## Output structure

\`\`\`
# {title}

> {description}        ← new (if set)

## {before-index heading}  ← new
{before-index content}

- [Page 1](...)        ← existing page tree
- [Page 2](...)

## {after-index heading}   ← new
{after-index content}
\`\`\`

## Tests

Added `packages/core/test/llms.test.ts` covering:
- H1 title + page index rendering (back-compat baseline)
- Description blockquote placement
- Before-index section placement + ordering
- Default position is `before-index`
- After-index section placement
- Multiple sections with mixed positions
- Back-compat: no visible change when options not provided

All 7 tests pass locally with \`vitest run test/llms.test.ts\`.

## Changeset

\`.changeset/llms-description-and-sections.md\` as \`fumadocs-core: minor\`.

## Related

A companion PR with a \`transform\` function alternative is being opened separately. The two approaches compose — you can ship either or both. This PR handles the common cases ergonomically; the other gives power users full output control.

Happy to iterate on the API based on your preferences.