### PR TITLE
feat(core): add transform option to llms.txt config

### DIFF
--- a/.changeset/llms-transform.md
+++ b/.changeset/llms-transform.md
@@ -1,0 +1,17 @@
+---
+'fumadocs-core': minor
+---
+
+Add a `transform` option to `LLMsConfig` for post-processing the generated `llms.txt` output.
+
+The callback receives the default auto-generated content and the render context, and returns the final string. Useful for injecting the description blockquote mandated by the [llms.txt spec](https://llmstxt.org/), custom sections, or any other site-specific content.
+
+```ts
+llms(source, {
+  transform: (output) =>
+    output.replace(
+      /^# (.+)\n/m,
+      '# $1\n\n> A knowledge base for humans and AI agents.\n',
+    ),
+}).index();
+```

--- a/packages/core/src/source/loader/llms.ts
+++ b/packages/core/src/source/loader/llms.ts
@@ -9,6 +9,28 @@ export interface LLMsConfig {
   TAB?: string;
   renderName?: (item: PageTree.Node | PageTree.Root, ctx: Context) => string;
   renderDescription?: (item: PageTree.Item | PageTree.Folder, ctx: Context) => string;
+  /**
+   * Post-process the rendered `llms.txt` output before it is returned.
+   * Receives the default auto-generated content and the render context;
+   * return the final string.
+   *
+   * Useful for injecting the description blockquote mandated by the
+   * llms.txt spec, custom sections (access patterns, license notes),
+   * or any other site-specific content the default generator doesn't
+   * produce.
+   *
+   * @example
+   * ```ts
+   * llms(source, {
+   *   transform: (output) =>
+   *     output.replace(
+   *       /^# (.+)\n/m,
+   *       '# $1\n\n> A knowledge base for humans and AI agents.\n',
+   *     ),
+   * }).index();
+   * ```
+   */
+  transform?: (output: string, ctx: Context) => string;
 }
 
 export function llms<C extends LoaderConfig>(loader: LoaderOutput<C>, config: LLMsConfig = {}) {
@@ -32,6 +54,7 @@ export function llms<C extends LoaderConfig>(loader: LoaderOutput<C>, config: LL
 
       return String(node.description);
     },
+    transform,
   } = config;
 
   function index(lang?: string): string {
@@ -81,7 +104,8 @@ export function llms<C extends LoaderConfig>(loader: LoaderOutput<C>, config: LL
     }
 
     for (const child of pageTree.children) onNode(child, 0);
-    return out.join('\n');
+    const output = out.join('\n');
+    return transform ? transform(output, ctx) : output;
   }
 
   return {

--- a/packages/core/test/llms.test.ts
+++ b/packages/core/test/llms.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'vitest';
+import { llms, loader } from '@/source';
+import { source } from './fixtures/page-trees/basic';
+
+test('llms: baseline — no transform (back-compat)', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+  ).index();
+
+  expect(output).toContain('# Docs');
+  expect(output).toContain('- [Hello](/docs/test)');
+});
+
+test('llms: transform receives default output and returns final string', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      transform: (defaultOutput) =>
+        `${defaultOutput}\n\n## License\n\nMIT.\n`,
+    },
+  ).index();
+
+  expect(output).toContain('# Docs');
+  expect(output).toContain('- [Hello](/docs/test)');
+  expect(output.trimEnd().endsWith('MIT.')).toBe(true);
+});
+
+test('llms: transform can inject description blockquote per llms.txt spec', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      transform: (defaultOutput) =>
+        defaultOutput.replace(
+          /^# (.+)\n/m,
+          '# $1\n\n> A knowledge base for humans and AI agents.\n',
+        ),
+    },
+  ).index();
+
+  expect(output).toMatch(/^# Docs\n\n> A knowledge base/);
+});
+
+test('llms: transform receives Context with lang on i18n loaders', () => {
+  let seenLang: string | undefined = 'sentinel';
+  llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      transform: (defaultOutput, ctx) => {
+        seenLang = ctx.lang;
+        return defaultOutput;
+      },
+    },
+  ).index();
+
+  // Without i18n config, lang is undefined.
+  expect(seenLang).toBeUndefined();
+});
+
+test('llms: transform return value is used as-is (can rewrite everything)', () => {
+  const output = llms(
+    loader({
+      baseUrl: '/docs',
+      source,
+    }),
+    {
+      transform: () => 'replaced entirely',
+    },
+  ).index();
+
+  expect(output).toBe('replaced entirely');
+});


### PR DESCRIPTION
Addresses #3186 (option 2 of 2).

## Summary

Adds a `transform` callback to `LLMsConfig` for post-processing the rendered `llms.txt` output. Receives the default auto-generated string and the render context, returns the final string.

## Motivation

The current `llms()` function generates a fixed structure (H1 title + page tree). There's no way to add a description blockquote, custom sections, or any other content the default generator doesn't produce. Users end up patching the output file at build time.

A `transform` function gives users maximum flexibility with minimal API surface.

## Usage

\`\`\`ts
// Inject the description blockquote mandated by the llms.txt spec
llms(source, {
  transform: (output) =>
    output.replace(
      /^# (.+)\n/m,
      '# $1\n\n> A knowledge base for humans and AI agents.\n',
    ),
}).index();

// Append a custom section
llms(source, {
  transform: (output) => \`\${output}\n\n## License\n\nMIT.\`,
}).index();
\`\`\`

## Tests

Added `packages/core/test/llms.test.ts` covering:
- Back-compat baseline (no transform, existing behavior unchanged)
- Transform receives default output, appends content
- Transform injecting llms.txt-spec description blockquote
- Transform receives Context with `lang`
- Transform can replace output entirely

All 5 tests pass locally with `vitest run test/llms.test.ts`.

## Changeset

`.changeset/llms-transform.md` as `fumadocs-core: minor`.

## Related

A companion PR with dedicated `description` and `sections` config fields is open separately (#3187). The two approaches compose — `transform` gives power users full control; the other covers common cases ergonomically without writing regex. You could ship either or both.

Happy to iterate on the API based on your preferences.