### PR TITLE
fix: fallback to default meta.json for locales

### DIFF
--- a/packages/core/src/source/storage/content.ts
+++ b/packages/core/src/source/storage/content.ts
@@ -63,6 +63,8 @@ const parsers = {
 };
 
 const EmptyLang = Symbol();
+/** non-locale meta files; applied to every locale storage before locale-specific files */
+const BaseLang = Symbol();
 
 /**
  * convert input files into virtual file system.
@@ -74,7 +76,7 @@ export function createContentStorageBuilder(loaderConfig: ResolvedLoaderConfig) 
 
   const parser = i18n ? parsers[i18n.parser ?? 'dot'] : parsers.none;
   const normalized = new Map<
-    string | typeof EmptyLang,
+    string | typeof EmptyLang | typeof BaseLang,
     {
       pathWithoutLocale: string;
       file: ContentStorageMetaFile | ContentStoragePageFile;
@@ -105,9 +107,9 @@ export function createContentStorageBuilder(loaderConfig: ResolvedLoaderConfig) 
         };
       }
 
-      const [pathWithoutLocale, locale = i18n ? i18n.defaultLanguage : EmptyLang] = parser(
-        file.path,
-      );
+      const [pathWithoutLocale, parsedLocale] = parser(file.path);
+      const locale =
+        parsedLocale ?? (i18n ? (file.format === 'meta' ? BaseLang : i18n.defaultLanguage) : EmptyLang);
       let list = normalized.get(locale);
       if (!list) {
         list = [];
@@ -129,6 +131,9 @@ export function createContentStorageBuilder(loaderConfig: ResolvedLoaderConfig) 
 
   function makeStorage(locale: string | typeof EmptyLang, inherit?: ContentStorage) {
     const storage = new FileSystem(inherit);
+    for (const { pathWithoutLocale, file } of normalized.get(BaseLang) ?? []) {
+      storage.write(pathWithoutLocale, file);
+    }
     for (const { pathWithoutLocale, file } of normalized.get(locale) ?? []) {
       storage.write(pathWithoutLocale, file);
     }

--- a/packages/core/test/loader.test.ts
+++ b/packages/core/test/loader.test.ts
@@ -431,3 +431,42 @@ test('Loader: Serialize data', async () => {
 
   expect(JSON.stringify(result.pageTree), 'page tree unchanged').toBe(prev);
 });
+
+const i18nMetaSource = {
+  files: [
+    { type: 'meta' as const, path: 'meta.json', data: { title: 'Docs', pages: ['shop-products', 'about', '...'] } },
+    { type: 'page' as const, path: 'shop-products.mdx', data: { title: 'Shop Products EN' } },
+    { type: 'page' as const, path: 'shop-products.fi.mdx', data: { title: 'Shop Products FI' } },
+    { type: 'page' as const, path: 'about.mdx', data: { title: 'About EN' } },
+    { type: 'page' as const, path: 'about.fi.mdx', data: { title: 'About FI' } },
+    { type: 'page' as const, path: 'aaaa.fi.mdx', data: { title: 'Aaaa FI' } },
+  ],
+};
+
+test('i18n: meta.json without locale applies pages order to all locales', () => {
+  const result = loader(i18nMetaSource, {
+    baseUrl: '/',
+    pageTree: { noRef: true },
+    i18n: { defaultLanguage: 'en', languages: ['en', 'fi'] },
+  });
+
+  const trees = result.pageTree as Record<string, any>;
+  expect(trees.en.children[0].name).toBe('Shop Products EN');
+  expect(trees.en.children[1].name).toBe('About EN');
+  expect(trees.fi.children[0].name).toBe('Shop Products FI');
+  expect(trees.fi.children[1].name).toBe('About FI');
+});
+
+test('i18n: meta.json without locale applies pages order to all locales (no fallback)', () => {
+  const result = loader(i18nMetaSource, {
+    baseUrl: '/',
+    pageTree: { noRef: true },
+    i18n: { defaultLanguage: 'en', languages: ['en', 'fi'], fallbackLanguage: null },
+  });
+
+  const trees = result.pageTree as Record<string, any>;
+  expect(trees.en.children[0].name).toBe('Shop Products EN');
+  expect(trees.en.children[1].name).toBe('About EN');
+  expect(trees.fi.children[0].name).toBe('Shop Products FI');
+  expect(trees.fi.children[1].name).toBe('About FI');
+});


### PR DESCRIPTION
meta.json without a locale suffix was assigned to the default language only, other locales got it via fallback inheritance. with `fallbackLanguage: null`, those locales never received it and fell back to alphabetical ordering.

After fix: non-locale meta.json files are treated as shared and written to every locale's storage, regardless of fallback config. Locale-specific meta.fi.json still takes precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced meta file handling in internationalized content, ensuring shared configurations without explicit locale assignments are consistently applied across all language versions

* **Tests**
  * Added i18n loader tests validating proper page ordering application and meta file configuration consistency across multiple locales

<!-- end of auto-generated comment: release notes by coderabbit.ai -->