### PR TITLE
Change "documentations" to "documentation"

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -75,7 +75,7 @@ export default function Page() {
           </p>
           <h1 className="text-4xl my-8 leading-tighter font-medium xl:text-5xl xl:mb-12">
             Build excellent
-            <br className="md:hidden" /> documentations,
+            <br className="md:hidden" /> documentation,
             <br />
             your <span className="text-brand">style</span>.
           </h1>

--- a/apps/docs/components/preview/index.tsx
+++ b/apps/docs/components/preview/index.tsx
@@ -108,7 +108,7 @@ export function accordion(): ReactNode {
     <Wrapper>
       <Accordions type="single" collapsible>
         <Accordion id="what-is-fumadocs" title="What is Fumadocs?">
-          A framework for building documentations
+          A framework for building documentation
         </Accordion>
         <Accordion id="ux" title="What do we love?">
           We love websites with a good user experience

--- a/apps/docs/content/docs/(framework)/guides/customize-ui.mdx
+++ b/apps/docs/content/docs/(framework)/guides/customize-ui.mdx
@@ -31,7 +31,7 @@ Or styling the container via props:
 </DocsLayout>
 ```
 
-Detailed documentations for each component are in the [Fumadocs UI](/docs/ui) section, you can take it as a reference.
+Detailed documentation for each component is in the [Fumadocs UI](/docs/ui) section, you can take it as a reference.
 
 Most options support passing JSX elements to allow your own components.
 This approach should suffice most use cases, such as adding sections below table of contents or in sidebar.


### PR DESCRIPTION
Documentation is one of those nounds that's always singular

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar in landing page headline by changing "documentations" to "documentation" (singular form).
  * Updated accordion content text from plural to singular form for consistency.
  * Refined wording in UI customization guide for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->