### PR TITLE
docs: replace "React.js" with "React" across the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![banner](./apps/docs/public/banner.png)
 
-The framework for building documentation websites in any React.js frameworks.
+The framework for building documentation websites in any React frameworks.
 
 **Officially Supported:**
 

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -454,8 +454,8 @@ function ForEngineers() {
           Framework Agnostic
         </h3>
         <p className="mb-20">
-          Official support for Next.js, Tanstack Start, React Router, Waku — portable to any
-          React framework.
+          Official support for Next.js, Tanstack Start, React Router, Waku — portable to any React
+          framework.
         </p>
         <div className="flex flex-row gap-2 mt-auto bg-brand text-brand-foreground rounded-xl p-2 w-fit">
           <svg

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -71,7 +71,7 @@ export default function Page() {
         <Hero />
         <div className="flex flex-col z-2 px-4 size-full md:p-12 max-md:items-center max-md:text-center">
           <p className="mt-12 text-xs text-brand font-medium rounded-full p-2 border border-brand/50 w-fit">
-            the React.js docs framework you love.
+            the React docs framework you love.
           </p>
           <h1 className="text-4xl my-8 leading-tighter font-medium xl:text-5xl xl:mb-12">
             Build excellent
@@ -96,11 +96,11 @@ export default function Page() {
       </div>
       <div className="grid grid-cols-1 gap-10 mt-12 px-6 mx-auto w-full max-w-[1400px] md:px-12 lg:grid-cols-2 lg:mt-20">
         <p className="text-2xl tracking-tight leading-snug font-light col-span-full md:text-3xl xl:text-4xl">
-          Fumadocs is a <span className="text-brand font-medium">React.js</span> documentation
+          Fumadocs is a <span className="text-brand font-medium">React</span> documentation
           framework for <span className="text-brand font-medium">Developers</span>, beautifully
           designed by <span className="text-brand font-medium">Fuma Nama</span>. Bringing powerful
           features for your docs workflows, with high customizability to fit your preferences, works
-          seamlessly with any React.js framework, CMS — anything.
+          seamlessly with any React framework, CMS — anything.
         </p>
         <div className="relative p-4 rounded-2xl col-span-full z-2 overflow-hidden md:p-8">
           <Image
@@ -455,7 +455,7 @@ function ForEngineers() {
         </h3>
         <p className="mb-20">
           Official support for Next.js, Tanstack Start, React Router, Waku — portable to any
-          React.js framework.
+          React framework.
         </p>
         <div className="flex flex-row gap-2 mt-auto bg-brand text-brand-foreground rounded-xl p-2 w-fit">
           <svg

--- a/apps/docs/app/export/epub/route.ts
+++ b/apps/docs/app/export/epub/route.ts
@@ -11,7 +11,7 @@ export async function GET(): Promise<Response> {
     },
     title: 'Fumadocs Documentation',
     author: 'Fuma Nama',
-    description: 'Documentation for Fumadocs - the React.js documentation framework',
+    description: 'Documentation for Fumadocs - the React documentation framework',
     cover: '/og.png',
   });
   return new Response(new Uint8Array(buffer), {

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata = createMetadata({
     template: '%s | Fumadocs',
     default: 'Fumadocs',
   },
-  description: 'The React.js documentation framework.',
+  description: 'The React documentation framework.',
   metadataBase: baseUrl,
 });
 

--- a/apps/docs/content/blog/v15-2.mdx
+++ b/apps/docs/content/blog/v15-2.mdx
@@ -13,7 +13,7 @@ Fumadocs 15.2 introduces a layer over `fumadocs-core` to extend support to other
 
 The main focus of Fumadocs is flexibility, I aim to support more frameworks as long as it doesn't change the fundamentals of Fumadocs, like the separation of core and UI package.
 
-The React.js ecosystem is a joy to work with, porting Fumadocs to other frameworks isn't as difficult as I thought.
+The React ecosystem is a joy to work with, porting Fumadocs to other frameworks isn't as difficult as I thought.
 It's also my goal to make it work not only for Next.js devs, but also everyone in the ecosystem who is using a SSR-compatible React framework.
 
 ### Breaking Changes
@@ -65,7 +65,7 @@ pnpm create fumadocs-app
 
 ### Future Plans
 
-15.2 doesn't support Astro, and probably won't unless better React.js support is provided by Astro.
+15.2 doesn't support Astro, and probably won't unless better React support is provided by Astro.
 
 - `transition:persist` is needed for Fumadocs UI layouts, however this will also affect its children (e.g. MDX content), causing page content to be persisted even after navigation.
 - React contexts cannot work across islands, this changes the usage of Fumadocs significantly and hence require a redesign of APIs.

--- a/apps/docs/content/blog/v16.mdx
+++ b/apps/docs/content/blog/v16.mdx
@@ -24,8 +24,8 @@ Fumadocs 16 removed substantial amount of deprecated APIs accumulated since v15.
 
 - **Default Switch to Shiki's JavaScript Regex Engine**: To ensure seamless compatibility with environments like Cloudflare Workers, the JavaScript engine is now the default over the WASM-based Oniguruma. This change affects `rehype-code` (via the `engine` option) and `fumadocs-core/highlight`.
 
-- **Minimum React.js Version Raised to 19.2.0**: React 19.2 brings crucial performance improvements to Fumadocs UI.
-  - **Next.js Projects**: Next.js projects using Fumadocs UI must use Next.js 16 or later, as Next.js uses its own canary channel for React.js.
+- **Minimum React Version Raised to 19.2.0**: React 19.2 brings crucial performance improvements to Fumadocs UI.
+  - **Next.js Projects**: Next.js projects using Fumadocs UI must use Next.js 16 or later, as Next.js uses its own canary channel for React.
 - **`fumadocs-ui/provider` is removed**:
   - Use `fumadocs-ui/provider/next` for root provider.
   - Use individual exports for contexts from `fumadocs-ui/contexts/*`.

--- a/apps/docs/content/blog/why-docs.mdx
+++ b/apps/docs/content/blog/why-docs.mdx
@@ -35,7 +35,7 @@ Of course, _Usually_ using things like GitHub Wiki is adequate, but it is not al
 Let's take Component Library for example, you cannot showcase your components with Markdown.
 You will constantly find an ordinary Markdown document lacks capability and flexibility.
 
-Documentation frameworks aim to solve this problem, with the ability to integrate with major libraries like **React.js** and **Vue.js**.
+Documentation frameworks aim to solve this problem, with the ability to integrate with major libraries like **React** and **Vue.js**.
 Good examples are Vitepress, Mintlify and Nextra - They made writing docs more convenient and effective, while offering a better, dedicated experience to readers.
 
 For anything more than a simple library or API service, **it is worth trying.**

--- a/apps/docs/content/docs/(framework)/comparisons.mdx
+++ b/apps/docs/content/docs/(framework)/comparisons.mdx
@@ -50,16 +50,16 @@ Mintlify is a documentation service, as compared to Fumadocs, it offers a free t
 
 Fumadocs is not as powerful as Mintlify, for example, the OpenAPI integration of Mintlify.
 As the creator of Fumadocs, I wouldn't recommend switching to Fumadocs from Mintlify if you're satisfied with the current way you build docs.
-However, I believe Fumadocs is a suitable tool for all React.js developers who want to have elegant docs.
+However, I believe Fumadocs is a suitable tool for all React developers who want to have elegant docs.
 
 ## Docusaurus
 
-Docusaurus is a powerful framework based on React.js. It offers many cool
+Docusaurus is a powerful framework based on React. It offers many cool
 features with plugins and custom themes.
 
 ### Lower Complexity
 
-As Fumadocs is designed to integrate with React frameworks, you may need more knowledge of React.js to get started.
+As Fumadocs is designed to integrate with React frameworks, you may need more knowledge of React to get started.
 In return, Fumadocs have better customizability.
 
 For a simple docs, Docusaurus might be a better choice if you don't need any framework-specific functionality.

--- a/apps/docs/content/docs/(framework)/guides/access-control.mdx
+++ b/apps/docs/content/docs/(framework)/guides/access-control.mdx
@@ -102,4 +102,4 @@ Note that it is up to you to manage the page tree (sidebar items), search and ot
 
 This approach offers the best flexibility, but it doesn't rely on Fumadocs itself for access control, the setup may take longer and be more complicated.
 
-It is better to consult the docs of your React.js framework when implementing.
+It is better to consult the docs of your React framework when implementing.

--- a/apps/docs/content/docs/(framework)/index.mdx
+++ b/apps/docs/content/docs/(framework)/index.mdx
@@ -51,7 +51,7 @@ A command line tool to install UI components and automate things, useful for cus
 
 **[Bun](https://bun.sh):** A JavaScript runtime, it will be used in our guides for running scripts. If you prefer Node.js, try [unrun](https://gugustinette.github.io/unrun/guide/getting-started.html#cli) instead.
 
-Some basic knowledge of React.js would be useful for further customizations.
+Some basic knowledge of React would be useful for further customizations.
 
 ## Automatic Installation
 
@@ -63,7 +63,7 @@ npm create fumadocs-app
 
 It will ask you the built-in template to use:
 
-- **React.js framework**: Next.js, Waku, React Router, Tanstack Start.
+- **React framework**: Next.js, Waku, React Router, Tanstack Start.
 - **Content source**: Fumadocs MDX.
 
 A new fumadocs app should be initialized, with following features configured by default:

--- a/apps/docs/content/docs/(framework)/integrations/content/custom.mdx
+++ b/apps/docs/content/docs/(framework)/integrations/content/custom.mdx
@@ -75,7 +75,7 @@ export default function Page({ params }: { params: { slug?: string[] } }) {
 
 #### Pre-rendering [step]
 
-The mechanism for pre-rendering differs depending on your React.js framework.
+The mechanism for pre-rendering differs depending on your React framework.
 
 It's important to pre-render pages (especially the frequently visited ones) to improve initial load time.
 

--- a/apps/docs/content/docs/(framework)/integrations/story/vite.mdx
+++ b/apps/docs/content/docs/(framework)/integrations/story/vite.mdx
@@ -87,7 +87,7 @@ export function MyComponent({ title }: MyComponentProps) {
 }
 ```
 
-Story clients require payloads from server to render, you can leverage the SSR functionality of your React.js framework.
+Story clients require payloads from server to render, you can leverage the SSR functionality of your React framework.
 
 For instance, on Tanstack Start:
 

--- a/apps/docs/content/docs/(framework)/what-is-fumadocs.mdx
+++ b/apps/docs/content/docs/(framework)/what-is-fumadocs.mdx
@@ -52,7 +52,7 @@ Fumadocs is designed with flexibility in mind, it is not limited to certain usag
 - `fumadocs-core` is a headless UI library for building docs.
 - `fumadocs-mdx` is a useful library to handle MDX content.
 
-For most of the web applications, vanilla React.js is no longer enough.
+For most of the web applications, vanilla React is no longer enough.
 Nowadays, we also wish to have a blog, a showcase page, a FAQ page, etc. In these cases, Fumadocs can help you build the
 docs easier, with less boilerplate.
 
@@ -67,7 +67,7 @@ You can take this site as an example of docs site built with Fumadocs.
 
 ### Blog sites
 
-Most React.js frameworks can already suffice the needs of a blog site.
+Most React frameworks can already suffice the needs of a blog site.
 
 Fumadocs provides additional tooling, including syntax highlighting, document search, and a default theme (Fumadocs UI).
 It helps you to avoid reinventing the wheels.

--- a/apps/docs/content/docs/headless/index.mdx
+++ b/apps/docs/content/docs/headless/index.mdx
@@ -6,7 +6,7 @@ icon: Album
 
 ## What is this?
 
-Fumadocs Core offers server-side functions and headless components to build docs on any React.js frameworks like Next.js.
+Fumadocs Core offers server-side functions and headless components to build docs on any React frameworks like Next.js.
 
 - Search (built-in: Orama, Algolia Search)
 - Breadcrumb, Sidebar, TOC Components

--- a/apps/docs/content/docs/headless/utils/negotiation.mdx
+++ b/apps/docs/content/docs/headless/utils/negotiation.mdx
@@ -5,7 +5,7 @@ description: Tiny wrapper for negotiation features.
 
 ## Overview
 
-For React.js frameworks supporting middlewares, you can use the Negotiation API of Fumadocs for basic functionalities.
+For React frameworks supporting middlewares, you can use the Negotiation API of Fumadocs for basic functionalities.
 
 It is a tiny wrapper of `negotiator`.
 

--- a/apps/docs/content/docs/mdx/entry/import.mdx
+++ b/apps/docs/content/docs/mdx/entry/import.mdx
@@ -89,6 +89,6 @@ export default defineConfig({
 
 <Callout title="Other Frameworks?">
 
-Other React.js frameworks like Tanstack Start usually prefer explicit declaration of loaders, it's recommended to use them as components in your pages instead.
+Other React frameworks like Tanstack Start usually prefer explicit declaration of loaders, it's recommended to use them as components in your pages instead.
 
 </Callout>

--- a/apps/docs/content/docs/ui/components/accordion.mdx
+++ b/apps/docs/content/docs/ui/components/accordion.mdx
@@ -27,7 +27,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 </Accordions>
 ```
 
-```tsx tab="React.js"
+```tsx tab="React"
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 export default function Page() {

--- a/apps/docs/content/docs/ui/components/dynamic-codeblock.mdx
+++ b/apps/docs/content/docs/ui/components/dynamic-codeblock.mdx
@@ -23,7 +23,7 @@ It highlights the code with Shiki and use the default component to render it.
 
 Features:
 
-- using React.js 19 Suspense.
+- using React 19 Suspense.
 - can be pre-rendered on server.
 - load languages and themes on browser lazily.
 

--- a/apps/docs/content/docs/ui/components/files.mdx
+++ b/apps/docs/content/docs/ui/components/files.mdx
@@ -8,7 +8,7 @@ preview: 'files'
 
 ## Usage
 
-Wrap file components in `Files`, you can use it in your MDX content, or as a normal React.js component.
+Wrap file components in `Files`, you can use it in your MDX content, or as a normal React component.
 
 ```mdx title="content.mdx"
 import { File, Folder, Files } from 'fumadocs-ui/components/files';

--- a/apps/docs/content/docs/ui/layouts/root-provider.mdx
+++ b/apps/docs/content/docs/ui/layouts/root-provider.mdx
@@ -7,7 +7,7 @@ The context provider of all the components, including `next-themes` and [`<Frame
 
 ## Usage
 
-Import it according to your React.js framework:
+Import it according to your React framework:
 
 ```jsx tab="Next.js"
 import { RootProvider } from 'fumadocs-ui/provider/next';

--- a/examples/react-router-i18n/app/routes/home.tsx
+++ b/examples/react-router-i18n/app/routes/home.tsx
@@ -16,7 +16,7 @@ export default function Home({ params }: Route.ComponentProps) {
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
         <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.js.
+          The truly flexible docs framework on React.
         </p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"

--- a/examples/react-router-i18n/app/routes/home.tsx
+++ b/examples/react-router-i18n/app/routes/home.tsx
@@ -15,9 +15,7 @@ export default function Home({ params }: Route.ComponentProps) {
     <HomeLayout {...baseOptions(params.lang)}>
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
-        <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.
-        </p>
+        <p className="text-fd-muted-foreground mb-4">The truly flexible docs framework on React.</p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"
           to="/docs"

--- a/examples/react-router-min/app/routes/home.tsx
+++ b/examples/react-router-min/app/routes/home.tsx
@@ -16,7 +16,7 @@ export default function Home() {
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
         <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.js.
+          The truly flexible docs framework on React.
         </p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"

--- a/examples/react-router-min/app/routes/home.tsx
+++ b/examples/react-router-min/app/routes/home.tsx
@@ -15,9 +15,7 @@ export default function Home() {
     <HomeLayout {...baseOptions()}>
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
-        <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.
-        </p>
+        <p className="text-fd-muted-foreground mb-4">The truly flexible docs framework on React.</p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"
           to="/docs"

--- a/examples/react-router-rsc/app/routes/home.tsx
+++ b/examples/react-router-rsc/app/routes/home.tsx
@@ -16,7 +16,7 @@ export function ServerComponent() {
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
         <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.js.
+          The truly flexible docs framework on React.
         </p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"

--- a/examples/react-router-rsc/app/routes/home.tsx
+++ b/examples/react-router-rsc/app/routes/home.tsx
@@ -15,9 +15,7 @@ export function ServerComponent() {
     <HomeLayout {...baseOptions()}>
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
-        <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.
-        </p>
+        <p className="text-fd-muted-foreground mb-4">The truly flexible docs framework on React.</p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"
           to="/docs"

--- a/examples/react-router-spa/app/routes/home.tsx
+++ b/examples/react-router-spa/app/routes/home.tsx
@@ -16,7 +16,7 @@ export default function Home() {
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
         <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.js.
+          The truly flexible docs framework on React.
         </p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"

--- a/examples/react-router-spa/app/routes/home.tsx
+++ b/examples/react-router-spa/app/routes/home.tsx
@@ -15,9 +15,7 @@ export default function Home() {
     <HomeLayout {...baseOptions()}>
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
-        <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.
-        </p>
+        <p className="text-fd-muted-foreground mb-4">The truly flexible docs framework on React.</p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"
           to="/docs"

--- a/examples/react-router/app/routes/home.tsx
+++ b/examples/react-router/app/routes/home.tsx
@@ -16,7 +16,7 @@ export default function Home() {
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
         <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.js.
+          The truly flexible docs framework on React.
         </p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"

--- a/examples/react-router/app/routes/home.tsx
+++ b/examples/react-router/app/routes/home.tsx
@@ -15,9 +15,7 @@ export default function Home() {
     <HomeLayout {...baseOptions()}>
       <div className="p-4 flex flex-col items-center justify-center text-center flex-1">
         <h1 className="text-xl font-bold mb-2">Fumadocs on React Router.</h1>
-        <p className="text-fd-muted-foreground mb-4">
-          The truly flexible docs framework on React.
-        </p>
+        <p className="text-fd-muted-foreground mb-4">The truly flexible docs framework on React.</p>
         <Link
           className="text-sm bg-fd-primary text-fd-primary-foreground rounded-full font-medium px-4 py-2.5"
           to="/docs"

--- a/packages/base-ui/README.md
+++ b/packages/base-ui/README.md
@@ -1,5 +1,5 @@
 # Fumadocs UI
 
-The React.js docs framework.
+The React docs framework.
 
 [Read Documentation](https://fumadocs.dev/docs/ui)

--- a/packages/base-ui/src/components/sidebar/base.tsx
+++ b/packages/base-ui/src/components/sidebar/base.tsx
@@ -53,7 +53,7 @@ export interface SidebarProviderProps {
   defaultOpenLevel?: number;
 
   /**
-   * Prefetch links, default behaviour depends on your React.js framework.
+   * Prefetch links, default behaviour depends on your React framework.
    */
   prefetch?: boolean;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fumadocs-core",
   "version": "16.8.11",
-  "description": "The React.js library for building a documentation website",
+  "description": "The React library for building a documentation website",
   "keywords": [
     "Docs",
     "Fumadocs"

--- a/packages/radix-ui/README.md
+++ b/packages/radix-ui/README.md
@@ -1,5 +1,5 @@
 # Fumadocs UI
 
-The React.js docs framework.
+The React docs framework.
 
 [Read Documentation](https://fumadocs.dev/docs/ui)

--- a/packages/radix-ui/src/components/sidebar/base.tsx
+++ b/packages/radix-ui/src/components/sidebar/base.tsx
@@ -53,7 +53,7 @@ export interface SidebarProviderProps {
   defaultOpenLevel?: number;
 
   /**
-   * Prefetch links, default behaviour depends on your React.js framework.
+   * Prefetch links, default behaviour depends on your React framework.
    */
   prefetch?: boolean;
 

--- a/packages/story/src/index.tsx
+++ b/packages/story/src/index.tsx
@@ -58,7 +58,7 @@ export { createFileSystemCache } from './cache/fs';
 export interface Story<C extends FC<any> = FC<any>> {
   /** render as a server component (require RSC). */
   WithControl: FC;
-  /** create a serialized client payload, you can pass it to `<StoryPayloadProvider />`. (for React.js frameworks with SSR support). */
+  /** create a serialized client payload, you can pass it to `<StoryPayloadProvider />`. (for React frameworks with SSR support). */
   getClientPayload: () => Promise<string>;
 
   _private_: {


### PR DESCRIPTION
## Summary

\"React.js\" is not the official name. It is just \"React\".

- Replace all occurrences of \"React.js\" with \"React\" in docs, source files, and examples
- Skip changelog files to preserve historical records as-is

## Related Issues

N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): terminology fix

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

N/A

## Additional Context

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology from "React.js" to "React" throughout documentation, blog posts, guides, and component references for consistency across the platform.

* **Chores**
  * Updated package descriptions and metadata to reflect terminology changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fuma-nama/fumadocs/pull/3285)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->