### PR TITLE
feat(ui): add reusable tags component

### DIFF
--- a/.changeset/slow-terms-listen.md
+++ b/.changeset/slow-terms-listen.md
@@ -1,0 +1,5 @@
+---
+'fumadocs-ui': patch
+---
+
+Add reusable tags components for rendering document and blog metadata tags.

--- a/apps/docs/components/preview/index.tsx
+++ b/apps/docs/components/preview/index.tsx
@@ -4,6 +4,7 @@ import { Card } from 'fumadocs-ui/components/card';
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Tag, TagList } from 'fumadocs-ui/components/tags';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { TypeTable } from 'fumadocs-ui/components/type-table';
 import { type ReactNode } from 'react';
@@ -189,6 +190,24 @@ export function steps(): ReactNode {
             <p>Some text here</p>
           </Step>
         </Steps>
+      </div>
+    </Wrapper>
+  );
+}
+
+export function tags(): ReactNode {
+  return (
+    <Wrapper>
+      <div className="rounded-xl bg-fd-background p-4">
+        <TagList>
+          <Tag href="#" count={12}>
+            react
+          </Tag>
+          <Tag href="#" active count={8}>
+            nextjs
+          </Tag>
+          <Tag>docs</Tag>
+        </TagList>
       </div>
     </Wrapper>
   );

--- a/apps/docs/content/docs/ui/components/tags.mdx
+++ b/apps/docs/content/docs/ui/components/tags.mdx
@@ -1,0 +1,123 @@
+---
+title: Tags
+description: Display document, blog, or archive tags
+preview: tags
+---
+
+import { Tag, TagList } from 'fumadocs-ui/components/tags';
+
+<Installation name="tags" />
+
+## Usage
+
+Use tags to display document metadata, blog categories, or archive filters.
+
+```tsx
+import { Tag, TagList } from 'fumadocs-ui/components/tags';
+
+<TagList>
+  <Tag href="/tags/react" count={8}>
+    react
+  </Tag>
+  <Tag href="/tags/nextjs" active count={4}>
+    nextjs
+  </Tag>
+  <Tag>docs</Tag>
+</TagList>;
+```
+
+<TagList>
+  <Tag href="#" count={8}>
+    react
+  </Tag>
+  <Tag href="#" active count={4}>
+    nextjs
+  </Tag>
+  <Tag>docs</Tag>
+</TagList>
+
+### Plain Tags
+
+Omit `href` to render a non-link tag.
+
+```tsx
+<TagList>
+  <Tag>react</Tag>
+  <Tag>nextjs</Tag>
+  <Tag>docs</Tag>
+</TagList>
+```
+
+### Frontmatter Tags
+
+With Fumadocs MDX, add `tags` to your frontmatter schema.
+
+```ts title="source.config.ts"
+import { defineDocs } from 'fumadocs-mdx/config';
+import { pageSchema } from 'fumadocs-core/source/schema';
+import { z } from 'zod';
+
+export const docs = defineDocs({
+  docs: {
+    schema: pageSchema.extend({
+      tags: z.array(z.string()).default([]),
+    }),
+  },
+});
+```
+
+Then render tags from the page data.
+
+```tsx title="app/docs/[[...slug]]/page.tsx"
+import { Tag, TagList } from 'fumadocs-ui/components/tags';
+
+<TagList>
+  {page.data.tags.map((tag) => (
+    <Tag key={tag} href={`/tags/${encodeURIComponent(tag)}`}>
+      {tag}
+    </Tag>
+  ))}
+</TagList>;
+```
+
+### Counts
+
+Pass a number or any React node to `count`. You can render counts from a record, `Map`,
+or array length.
+
+```tsx
+const tagCounts = new Map([
+  ['react', 8],
+  ['nextjs', 4],
+]);
+
+<TagList>
+  {Array.from(tagCounts).map(([tag, count]) => (
+    <Tag key={tag} href={`/tags/${tag}`} count={count}>
+      {tag}
+    </Tag>
+  ))}
+</TagList>;
+```
+
+### Custom Styles
+
+Use `className` to customize the list or individual tags.
+
+```tsx
+<TagList className="gap-1">
+  <Tag className="uppercase">react</Tag>
+  <Tag active>nextjs</Tag>
+</TagList>
+```
+
+## Search Tags
+
+For search result filtering, use `TagsList` from `fumadocs-ui/components/dialog/search`
+instead.
+
+## Reference
+
+### Tag
+
+<auto-type-table cwd path="content/docs/ui/props.ts" name="TagProps" />

--- a/apps/docs/content/docs/ui/components/tags.mdx
+++ b/apps/docs/content/docs/ui/components/tags.mdx
@@ -93,7 +93,7 @@ const tagCounts = new Map([
 
 <TagList>
   {Array.from(tagCounts).map(([tag, count]) => (
-    <Tag key={tag} href={`/tags/${tag}`} count={count}>
+    <Tag key={tag} href={`/tags/${encodeURIComponent(tag)}`} count={count}>
       {tag}
     </Tag>
   ))}

--- a/apps/docs/content/docs/ui/props.ts
+++ b/apps/docs/content/docs/ui/props.ts
@@ -2,6 +2,7 @@ import type { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 import type { Callout } from 'fumadocs-ui/components/callout';
 import type { File, Folder } from 'fumadocs-ui/components/files';
 import type { InlineTOC } from 'fumadocs-ui/components/inline-toc';
+import type { TagProps as BaseTagProps } from 'fumadocs-ui/components/tags';
 import type { TypeTable } from 'fumadocs-ui/components/type-table';
 import type { Card } from 'fumadocs-ui/components/card';
 import type { DocsLayoutProps } from 'fumadocs-ui/layouts/docs';
@@ -43,6 +44,8 @@ export type CardProps = Omit<
   ComponentPropsWithoutRef<typeof Card>,
   keyof Omit<ComponentProps<'a'>, 'href'>
 >;
+
+export type TagProps = Omit<BaseTagProps, keyof Omit<ComponentProps<'a'>, 'href'>>;
 
 export type TypeTableProps = Omit<
   ComponentPropsWithoutRef<typeof TypeTable>,

--- a/packages/radix-ui/package.json
+++ b/packages/radix-ui/package.json
@@ -40,6 +40,7 @@
     "./components/sidebar/tabs/dropdown": "./dist/components/sidebar/tabs/dropdown.js",
     "./components/steps": "./dist/components/steps.js",
     "./components/tabs": "./dist/components/tabs.js",
+    "./components/tags": "./dist/components/tags.js",
     "./components/toc": "./dist/components/toc/index.js",
     "./components/toc/clerk": "./dist/components/toc/clerk.js",
     "./components/toc/default": "./dist/components/toc/default.js",

--- a/packages/radix-ui/registry/index.ts
+++ b/packages/radix-ui/registry/index.ts
@@ -265,6 +265,15 @@ export const registry: Registry = {
       ],
     },
     {
+      name: 'tags',
+      files: [
+        {
+          type: 'components',
+          path: 'components/tags.tsx',
+        },
+      ],
+    },
+    {
       name: 'tabs',
       files: [
         {

--- a/packages/radix-ui/src/components/tags.tsx
+++ b/packages/radix-ui/src/components/tags.tsx
@@ -1,0 +1,57 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, ReactNode } from 'react';
+import { cn } from '@/utils/cn';
+
+export function TagList({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div {...props} className={cn('not-prose flex flex-wrap items-center gap-2', className)} />
+  );
+}
+
+const tagVariants = cva(
+  'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium no-underline transition-colors',
+  {
+    variants: {
+      active: {
+        true: 'border-fd-border bg-fd-accent text-fd-accent-foreground',
+        false:
+          'border-fd-border text-fd-muted-foreground hover:bg-fd-accent hover:text-fd-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      active: false,
+    },
+  },
+);
+
+export type TagProps = {
+  children: ReactNode;
+  count?: ReactNode;
+} & VariantProps<typeof tagVariants> &
+  (
+    | ({ href: string } & Omit<ComponentProps<'a'>, 'children' | 'href'>)
+    | ({ href?: undefined } & Omit<ComponentProps<'span'>, 'children'>)
+  );
+
+export function Tag({ active, count, children, className, ...props }: TagProps) {
+  const content = (
+    <>
+      <span>{children}</span>
+      {count != null ? <span className="ms-1 text-fd-muted-foreground">{count}</span> : null}
+    </>
+  );
+
+  if (props.href !== undefined) {
+    return (
+      <a {...props} data-active={active} className={cn(tagVariants({ active }), className)}>
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <span {...props} data-active={active} className={cn(tagVariants({ active }), className)}>
+      {content}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
Add a reusable `TagList` and `Tag` component under `fumadocs-ui/components/tags`.

Fumadocs already has search-specific `TagsList` components under `fumadocs-ui/components/dialog/search`, but those are tied to filter state and button interactions. This PR adds a small UI primitive for rendering document/blog metadata tags from frontmatter, tag archive pages, or static tag lists.

It also adds docs, preview, props reference, and registry support.

## Related Issues
Closes #3299

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
Validation run locally:

- `pnpm --filter fumadocs-ui types:check`
- `pnpm --filter fumadocs-ui lint`
- `pnpm --filter fumadocs-ui build`
- `pnpm --filter docs lint`
- `pnpm --filter docs types:check`
- `pnpm lint:format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Tags UI component supporting linked and plain tags, optional count, active styling, and custom className.
  * Added a preview/example of the Tags component in the docs site.

* **Documentation**
  * New comprehensive Tags docs with usage patterns, examples (linked/plain/frontmatter-driven), count sources, styling tips, and a TagProps reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fuma-nama/fumadocs/pull/3300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->