### PR TITLE
docs: document LLM_GATEWAY_MODEL for Ask AI

### DIFF
--- a/apps/docs/content/docs/(framework)/integrations/llms.mdx
+++ b/apps/docs/content/docs/(framework)/integrations/llms.mdx
@@ -418,6 +418,13 @@ Add your LLMGateway API key to environment variables:
 LLM_GATEWAY_API_KEY="..."
 ```
 
+By default the route uses `anthropic/claude-3.5-sonnet`. To switch to any other model supported by LLMGateway, set the `LLM_GATEWAY_MODEL` environment variable—no code change required:
+
+```dotenv
+# any model id from https://llmgateway.io/models
+LLM_GATEWAY_MODEL="openai/gpt-4o"
+```
+
 </Tab>
 <Tab>
 


### PR DESCRIPTION
## What

Documents the optional `LLM_GATEWAY_MODEL` environment variable in the LLMGateway "Ask AI" tab of the AI & LLMs integration guide.

## Why

The `ai/llmgateway` route handler reads `LLM_GATEWAY_MODEL` (defaulting to `anthropic/claude-3.5-sonnet`) so users can switch among the 300+ models LLMGateway proxies without editing code. This wasn't mentioned in the docs—only `LLM_GATEWAY_API_KEY` was—so the model-switching capability was undiscoverable.

This is a docs-only follow-up to #3318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LLMGateway setup guide to document model selection via environment variables, including the default model configuration and examples for switching between different LLM providers without code changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fuma-nama/fumadocs/pull/3319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->