### PR TITLE
Add Fumadocs package bugs metadata

### DIFF
--- a/.changeset/add-package-bugs-metadata.md
+++ b/.changeset/add-package-bugs-metadata.md
@@ -1,0 +1,6 @@
+---
+'fumadocs-core': patch
+'fumadocs-mdx': patch
+---
+
+Add package issue tracker metadata.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,9 @@
   "license": "MIT",
   "author": "Fuma Nama",
   "repository": "github:fuma-nama/fumadocs",
+  "bugs": {
+    "url": "https://github.com/fuma-nama/fumadocs/issues"
+  },
   "files": [
     "dist"
   ],

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -10,6 +10,9 @@
   "license": "MIT",
   "author": "Fuma Nama",
   "repository": "github:fuma-nama/fumadocs",
+  "bugs": {
+    "url": "https://github.com/fuma-nama/fumadocs/issues"
+  },
   "bin": {
     "fumadocs-mdx": "./bin.js"
   },


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `fumadocs-core`
- add npm `bugs.url` metadata for `fumadocs-mdx`

## Verification
- `node -e "const core=require('./packages/core/package.json'); const mdx=require('./packages/mdx/package.json'); const expected='https://github.com/fuma-nama/fumadocs/issues'; if(core.bugs?.url!==expected) process.exit(1); if(mdx.bugs?.url!==expected) process.exit(1); console.log(JSON.stringify({core:core.bugs,mdx:mdx.bugs}))"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts ./packages/core`
- `npm pack --dry-run --ignore-scripts ./packages/mdx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added issue-tracker metadata to the core and mdx packages to make it easier for users to report bugs.
  * Added a changeset marking both packages for patch releases to record the metadata update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->