### PR TITLE
chore: add fumadocs-ui bugs metadata

### DIFF
--- a/packages/radix-ui/package.json
+++ b/packages/radix-ui/package.json
@@ -10,6 +10,9 @@
   "license": "MIT",
   "author": "Fuma Nama",
   "repository": "github:fuma-nama/fumadocs",
+  "bugs": {
+    "url": "https://github.com/fuma-nama/fumadocs/issues"
+  },
   "files": [
     "css",
     "dist"


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata to the `fumadocs-ui` package manifest
- point users and npm tooling to the existing Fumadocs GitHub issue tracker

## Verification
- `node -e "const p=require('./packages/radix-ui/package.json'); const expected='https://github.com/fuma-nama/fumadocs/issues'; if(p.bugs?.url!==expected) process.exit(1); console.log(JSON.stringify({name:p.name,bugs:p.bugs}))"`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include a direct link to the project's issue tracker for bug reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->