### PR TITLE
fix(ui): use `prompt` query param for "Open in ChatGPT" page action

### DIFF
--- a/.tegami/2026-06-18-chatgpt-prompt-param.md
+++ b/.tegami/2026-06-18-chatgpt-prompt-param.md
@@ -1,0 +1,7 @@
+---
+packages: ['npm:fumadocs-ui', 'npm:@fumadocs/base-ui']
+---
+
+### Fix "Open in ChatGPT" page action URL
+
+ChatGPT now uses the `prompt` query parameter (it redirects `q` to `prompt`), so the page action link is built as `https://chatgpt.com/?prompt=...&hints=search` to open reliably.

--- a/packages/base-ui/src/layouts/shared/page-actions.tsx
+++ b/packages/base-ui/src/layouts/shared/page-actions.tsx
@@ -172,8 +172,8 @@ export function ViewOptionsPopover({
       {
         title: t('Open in ChatGPT'),
         href: `https://chatgpt.com/?${new URLSearchParams({
+          prompt: q,
           hints: 'search',
-          q,
         })}`,
         icon: (
           <svg

--- a/packages/radix-ui/src/layouts/shared/page-actions.tsx
+++ b/packages/radix-ui/src/layouts/shared/page-actions.tsx
@@ -173,8 +173,8 @@ export function ViewOptionsPopover({
       {
         title: t('Open in ChatGPT'),
         href: `https://chatgpt.com/?${new URLSearchParams({
+          prompt: q,
           hints: 'search',
-          q,
         })}`,
         icon: (
           <svg


### PR DESCRIPTION
## Summary
  The "Open in ChatGPT" page action generates its link using the `q` query
  parameter (`https://chatgpt.com/?hints=search&q=...`). ChatGPT now internally
  redirects `?q=` to `?prompt=`, and relying on that redirect is unreliable — the
  prompt frequently fails to open.

  This PR builds the URL with the current `prompt` parameter directly:

  - **Before:** `https://chatgpt.com/?hints=search&q=Read+<url>%2C+I+want+to+ask+questions+about+it.`
  - **After:**  `https://chatgpt.com/?prompt=Read+<url>%2C+I+want+to+ask+questions+about+it.&hints=search`

  The fix is applied in both packages that ship this component: `fumadocs-ui`
  and `@fumadocs/base-ui`. Other providers (Claude, Scira, Cursor) are unchanged.

  Reference confirming the `q` → `prompt` change:
  https://community.openai.com/t/query-parameters-in-chatgpt/1027747

  ## Related Issues
  N/A

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Other (please describe):

  ## Checklist
  - [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
  - [x] My code follows the code style of this project
  - [ ] I have added tests where applicable
  - [x] I have tested my changes locally
  - [ ] I have linked relevant issues
  - [ ] I have added screenshots for UI changes (if applicable)

  ## Screenshots (if applicable)
  No visual change — only the generated ChatGPT URL is affected (see Summary).

  ## Additional Context
  Added a `.tegami` changelog entry (patch) covering `fumadocs-ui` and
  `@fumadocs/base-ui`.

  That's ready to paste as-is. After submitting, CI (lint.yml) will run automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Open in ChatGPT" link to use the correct URL parameter format for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->