### PR TITLE
fix(tanstack-start): use validator instead of inputValidator (deprecated)

### DIFF
--- a/apps/docs/content/docs/(framework)/integrations/asyncapi/index.mdx
+++ b/apps/docs/content/docs/(framework)/integrations/asyncapi/index.mdx
@@ -253,7 +253,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);
     if (!page) throw notFound();

--- a/apps/docs/content/docs/(framework)/integrations/content/local-md.mdx
+++ b/apps/docs/content/docs/(framework)/integrations/content/local-md.mdx
@@ -290,7 +290,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const source = await getSource();
     const page = source.getPage(slugs);

--- a/apps/docs/content/docs/(framework)/integrations/openapi/index.mdx
+++ b/apps/docs/content/docs/(framework)/integrations/openapi/index.mdx
@@ -253,7 +253,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);
     if (!page) throw notFound();

--- a/apps/docs/content/docs/(framework)/internationalization/tanstack-start.mdx
+++ b/apps/docs/content/docs/(framework)/internationalization/tanstack-start.mdx
@@ -155,7 +155,7 @@ export const Route = createFileRoute('/$lang/docs/$')({
 const loader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((params: { slugs: string[]; lang?: string }) => params)
+  .validator((params: { slugs: string[]; lang?: string }) => params)
   .handler(async ({ data: { slugs, lang } }) => {
     const page = source.getPage(slugs, lang);
     if (!page) throw notFound();

--- a/apps/docs/content/docs/mdx/entry/browser.mdx
+++ b/apps/docs/content/docs/mdx/entry/browser.mdx
@@ -77,7 +77,7 @@ export const Route = createFileRoute('/docs/$')({
 const loader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);
     if (!page) throw notFound();

--- a/examples/tanstack-start-i18n/src/routes/$lang/docs/$.tsx
+++ b/examples/tanstack-start-i18n/src/routes/$lang/docs/$.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/$lang/docs/$')({
 const loader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((params: { slugs: string[]; lang?: string }) => params)
+  .validator((params: { slugs: string[]; lang?: string }) => params)
   .handler(async ({ data: { slugs, lang } }) => {
     const page = source.getPage(slugs, lang);
     if (!page) throw notFound();

--- a/examples/tanstack-start-local-md/src/routes/docs/$.tsx
+++ b/examples/tanstack-start-local-md/src/routes/docs/$.tsx
@@ -28,7 +28,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const source = await getSource();
     const page = source.getPage(slugs);

--- a/examples/tanstack-start-min/src/routes/docs/$.tsx
+++ b/examples/tanstack-start-min/src/routes/docs/$.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);
     if (!page) throw notFound();

--- a/examples/tanstack-start-openapi/src/routes/docs/$.tsx
+++ b/examples/tanstack-start-openapi/src/routes/docs/$.tsx
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);
     if (!page) throw notFound();

--- a/examples/tanstack-start-spa/src/routes/docs/$.tsx
+++ b/examples/tanstack-start-spa/src/routes/docs/$.tsx
@@ -31,7 +31,7 @@ export const Route = createFileRoute('/docs/$')({
 const loader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .middleware([staticFunctionMiddleware])
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);

--- a/examples/tanstack-start-story/src/routes/docs/$.tsx
+++ b/examples/tanstack-start-story/src/routes/docs/$.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);
     if (!page) throw notFound();

--- a/examples/tanstack-start/src/routes/docs/$.tsx
+++ b/examples/tanstack-start/src/routes/docs/$.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slugs: string[]) => slugs)
+  .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);
     if (!page) throw notFound();


### PR DESCRIPTION
## Summary

As per https://github.com/TanStack/router/pull/7566:

> inputValidator is deprecated and will be removed soon
>
> ## Summary by CodeRabbit
> 
> * **New Features**
>       
>   * Added `validator()` as the canonical method for server function and middleware input validation.
> 
> * **Deprecations**
>       
>   * `inputValidator()` is now deprecated; use `validator()` instead. Compiler warnings are emitted for remaining uses.
> 
> * **Documentation**
>       
>   * Updated all guides and examples to use the new `validator()` API across React, Solid, and Vue frameworks.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)

- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multiple code examples to use the latest server input validation syntax.
  * Added clearer type annotations in sample code where applicable.
* **Bug Fixes**
  * Aligned example snippets across docs and starter projects for consistency.
  * No user-facing behavior changes; runtime flows remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->