### PR TITLE
fix(tanstack-start): vite should be a dev dependency

### DIFF
--- a/examples/tanstack-start-i18n/package.json
+++ b/examples/tanstack-start-i18n/package.json
@@ -21,8 +21,7 @@
     "lucide-static": "^1.20.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "tailwind-merge": "^3.6.0",
-    "vite": "^8.0.16"
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",
@@ -32,6 +31,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/examples/tanstack-start-local-md/package.json
+++ b/examples/tanstack-start-local-md/package.json
@@ -20,8 +20,7 @@
     "lucide-react": "^1.20.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "tailwind-merge": "^3.6.0",
-    "vite": "^8.0.16"
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",
@@ -32,6 +31,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "nitro": "3.0.260610-beta",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/examples/tanstack-start-min/package.json
+++ b/examples/tanstack-start-min/package.json
@@ -19,8 +19,7 @@
     "fumadocs-ui": "workspace:*",
     "lucide-react": "^1.20.0",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "vite": "^8.0.16"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",
@@ -32,6 +31,7 @@
     "nitro": "3.0.260610-beta",
     "srvx": "^0.11.16",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/examples/tanstack-start-openapi/package.json
+++ b/examples/tanstack-start-openapi/package.json
@@ -22,8 +22,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "shiki": "^4.2.0",
-    "tailwind-merge": "^3.6.0",
-    "vite": "^8.0.16"
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",
@@ -34,6 +33,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "nitro": "3.0.260610-beta",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/examples/tanstack-start-spa/package.json
+++ b/examples/tanstack-start-spa/package.json
@@ -22,8 +22,7 @@
     "lucide-react": "^1.20.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "tailwind-merge": "^3.6.0",
-    "vite": "^8.0.16"
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",
@@ -36,6 +35,7 @@
     "serve": "^14.2.6",
     "srvx": "^0.11.16",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/examples/tanstack-start-story/package.json
+++ b/examples/tanstack-start-story/package.json
@@ -20,8 +20,7 @@
     "lucide-react": "^1.20.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "tailwind-merge": "^3.6.0",
-    "vite": "^8.0.16"
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",
@@ -31,6 +30,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -20,8 +20,7 @@
     "lucide-react": "^1.20.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "tailwind-merge": "^3.6.0",
-    "vite": "^8.0.16"
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",
@@ -32,6 +31,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "nitro": "3.0.260610-beta",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }


### PR DESCRIPTION
## Summary

Move vite from `dependencies` to `devDependencies` across multiple Tanstack Start templates


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Additional Context

Vite isn't needed in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several example app configurations to list a build tool as a development-only dependency.
  * No user-facing behavior, features, or UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->