### PR TITLE
fix(tanstack-start-spa): remove getPageMarkdownUrl, unused and identical to slugsToMarkdownPath

### DIFF
--- a/examples/tanstack-start-spa/src/lib/source.ts
+++ b/examples/tanstack-start-spa/src/lib/source.ts
@@ -32,20 +32,6 @@ export function slugsToMarkdownPath(slugs: string[]) {
   };
 }
 
-export function getPageMarkdownUrl(slugs: string[]) {
-  const segments = [...slugs];
-  if (segments.length === 0) {
-    segments.push('index.md');
-  } else {
-    segments[segments.length - 1] += '.md';
-  }
-
-  return {
-    segments,
-    url: `${docsRoute}/${segments.join('/')}`,
-  };
-}
-
 export async function getLLMText(page: (typeof source)['$inferPage']) {
   const processed = await page.data.getText('processed');
 


### PR DESCRIPTION
## Summary

Remove `getPageMarkdownUrl`, unused and identical to `slugsToMarkdownPath` (directly above it).

See changes tab:

<img width="1000" alt="pr-3379-changes-tab" src="https://github.com/user-attachments/assets/063204b7-dab0-4708-908c-efecafcb04f5" />

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated page-to-markdown path handling to produce consistent document URLs from slug segments.
  * Empty slugs now map to an index markdown page, while nested slugs correctly resolve to markdown files.
  * Page text generation continues to include the page title, page URL, and processed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->