### PR TITLE
style(tanstack-start--spa): biome version + sort order

### DIFF
--- a/examples/tanstack-start-spa/src/components/not-found.tsx
+++ b/examples/tanstack-start-spa/src/components/not-found.tsx
@@ -1,6 +1,6 @@
-import { baseOptions } from '@/lib/layout.shared';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import { DefaultNotFound } from 'fumadocs-ui/layouts/home/not-found';
+import { baseOptions } from '@/lib/layout.shared';
 
 export function NotFound() {
   return (

--- a/examples/tanstack-start-spa/src/components/search.tsx
+++ b/examples/tanstack-start-spa/src/components/search.tsx
@@ -1,4 +1,7 @@
 'use client';
+import { create } from '@orama/orama';
+import { useDocsSearch } from 'fumadocs-core/search/client';
+import { oramaStaticClient } from 'fumadocs-core/search/client/orama-static';
 import {
   SearchDialog,
   SearchDialogClose,
@@ -10,9 +13,6 @@ import {
   SearchDialogOverlay,
   type SharedProps,
 } from 'fumadocs-ui/components/dialog/search';
-import { useDocsSearch } from 'fumadocs-core/search/client';
-import { oramaStaticClient } from 'fumadocs-core/search/client/orama-static';
-import { create } from '@orama/orama';
 import { useI18n } from 'fumadocs-ui/contexts/i18n';
 
 function initOrama() {

--- a/examples/tanstack-start-spa/src/lib/source.ts
+++ b/examples/tanstack-start-spa/src/lib/source.ts
@@ -1,6 +1,6 @@
+import { docs } from 'collections/server';
 import { loader } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
-import { docs } from 'collections/server';
 import { docsRoute } from './shared';
 
 export const source = loader({

--- a/examples/tanstack-start-spa/src/router.tsx
+++ b/examples/tanstack-start-spa/src/router.tsx
@@ -1,6 +1,6 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router';
-import { routeTree } from './routeTree.gen';
 import { NotFound } from '@/components/not-found';
+import { routeTree } from './routeTree.gen';
 
 export function getRouter() {
   return createTanStackRouter({

--- a/examples/tanstack-start-spa/src/routes/__root.tsx
+++ b/examples/tanstack-start-spa/src/routes/__root.tsx
@@ -1,8 +1,7 @@
 import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router';
-import * as React from 'react';
-import appCss from '@/styles/app.css?url';
 import { RootProvider } from 'fumadocs-ui/provider/tanstack';
 import SearchDialog from '@/components/search';
+import appCss from '@/styles/app.css?url';
 
 export const Route = createRootRoute({
   head: () => ({
@@ -25,7 +24,7 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <html suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>

--- a/examples/tanstack-start-spa/src/routes/api/search.ts
+++ b/examples/tanstack-start-spa/src/routes/api/search.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
+import { source } from '@/lib/source';
 
 const server = createFromSource(source, {
   // https://docs.orama.com/docs/orama-js/supported-languages

--- a/examples/tanstack-start-spa/src/routes/docs/$.tsx
+++ b/examples/tanstack-start-spa/src/routes/docs/$.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
-import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { createServerFn } from '@tanstack/react-start';
-import { slugsToMarkdownPath, source } from '@/lib/source';
+import { staticFunctionMiddleware } from '@tanstack/start-static-server-functions';
 import browserCollections from 'collections/browser';
+import { useFumadocsLoader } from 'fumadocs-core/source/client';
+import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import {
   DocsBody,
   DocsDescription,
@@ -11,12 +12,11 @@ import {
   MarkdownCopyButton,
   ViewOptionsPopover,
 } from 'fumadocs-ui/layouts/docs/page';
-import { baseOptions } from '@/lib/layout.shared';
-import { gitConfig } from '@/lib/shared';
-import { staticFunctionMiddleware } from '@tanstack/start-static-server-functions';
-import { useFumadocsLoader } from 'fumadocs-core/source/client';
 import { Suspense } from 'react';
 import { useMDXComponents } from '@/components/mdx';
+import { baseOptions } from '@/lib/layout.shared';
+import { gitConfig } from '@/lib/shared';
+import { slugsToMarkdownPath, source } from '@/lib/source';
 
 export const Route = createFileRoute('/docs/$')({
   component: Page,

--- a/examples/tanstack-start-spa/src/routes/llms-full[.]txt.ts
+++ b/examples/tanstack-start-spa/src/routes/llms-full[.]txt.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { source, getLLMText } from '@/lib/source';
+import { getLLMText, source } from '@/lib/source';
 
 export const Route = createFileRoute('/llms-full.txt')({
   server: {

--- a/examples/tanstack-start-spa/src/routes/llms[.]txt.ts
+++ b/examples/tanstack-start-spa/src/routes/llms[.]txt.ts
@@ -1,6 +1,6 @@
-import { source } from '@/lib/source';
 import { createFileRoute } from '@tanstack/react-router';
 import { llms } from 'fumadocs-core/source';
+import { source } from '@/lib/source';
 
 export const Route = createFileRoute('/llms.txt')({
   server: {

--- a/examples/tanstack-start-spa/vite.config.ts
+++ b/examples/tanstack-start-spa/vite.config.ts
@@ -1,9 +1,9 @@
-import react from '@vitejs/plugin-react';
-import { tanstackStart } from '@tanstack/react-start/plugin/vite';
-import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
+import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+import react from '@vitejs/plugin-react';
 import mdx from 'fumadocs-mdx/vite';
 import { nitro } from 'nitro/vite';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   server: {

--- a/packages/create-app/src/plugins/biome.base.json
+++ b/packages/create-app/src/plugins/biome.base.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     },
     "domains": {
       "react": "recommended"

--- a/packages/create-app/src/plugins/biome.ts
+++ b/packages/create-app/src/plugins/biome.ts
@@ -24,7 +24,7 @@ export function biome(): TemplatePlugin {
     async afterWrite() {
       const config = this.template.value.startsWith('+next') ? next : base;
 
-      await writeFile(path.join(this.dest, 'biome.json'), JSON.stringify(config, null, 2));
+      await writeFile(path.join(this.dest, 'biome.json'), JSON.stringify(config, null, 2) + '\n');
       this.log('Configured Biome');
     },
   };


### PR DESCRIPTION
## Summary

Apply biome default style fixes for import order and HTML lang for the Tanstack Start SPA template.

Conflicting changes with fumadocs' `oxfmt`, such as line length and quote style, were ignored.


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): style fixes

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)
