### PR TITLE
feat(satteri): add @fumadocs/satteri and compiler: satteri in fumadocs-mdx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Fumadocs is a **pnpm + Turborepo monorepo** (`packages/*` libraries, `apps/docs` the fumadocs.dev site, `examples/*` sample apps). Standard commands live in `.github/contributing.md`, root `package.json`, and each package's `package.json` — refer to those rather than duplicating.
+
+### Toolchain (already provisioned in the VM snapshot)
+- Requires **Node >= 24.14.0** (root `engines`). The VM's `nvm` default is Node 24 and `~/.bashrc` prepends it to `PATH` so it beats the system `/exec-daemon` Node 22. `pnpm@11.5.3` is provided by `corepack`. New shells pick this up automatically; if a shell somehow shows Node 22, run `source ~/.bashrc`.
+- The update script only runs `pnpm install --frozen-lockfile`. Everything below is manual.
+
+### Must build packages before running any app
+Libraries build with `tsdown` (not a dev server) and apps consume them from `dist/` via `workspace:*`. Before running/dev-ing `apps/docs` or any example, run once:
+`pnpm run build --filter='./packages/*'`
+The `[WARN] Failed to create bin ... dist/index.js` messages during `pnpm install` are expected before this build and disappear afterward.
+
+### Running the docs site (primary manual-test target)
+`pnpm run dev --filter=docs` → http://localhost:3000 (Next.js + Turbopack). No environment variables are required — search/AI/GitHub features are optional (see `turbo.json` `globalEnv`) and the site renders and searches fine without them. First page compile is slow (Turbopack compiles on first request).
+
+### Test / lint / types gotchas
+- `pnpm test` runs `vitest` in watch mode (blocks a TTY). For a one-shot run use `pnpm exec vitest run`.
+- `pnpm lint` = oxlint (fast). `pnpm lint:format` = `oxfmt --check`; `pnpm format` fixes.
+- `pnpm types:check` type-checks all packages.

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -54,6 +54,7 @@
     "types:check": "tsc --noEmit"
   },
   "dependencies": {
+    "@fumadocs/satteri": "workspace:*",
     "@mdx-js/mdx": "^3.1.1",
     "@standard-schema/spec": "^1.1.0",
     "chokidar": "^5.0.0",
@@ -87,6 +88,7 @@
     "remark-directive": "^4.0.0",
     "remark-mdx": "^3.1.1",
     "rolldown": "^1.1.2",
+    "satteri": "^0.9.4",
     "tsconfig": "workspace:*",
     "tsdown": "0.22.3",
     "vite": "^8.1.0",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -26,6 +26,7 @@
     "./bin": "./dist/bin.js",
     "./bun": "./dist/bun/index.js",
     "./config": "./dist/config/index.js",
+    "./config/satteri": "./dist/config/satteri/index.js",
     "./next": "./dist/next/index.js",
     "./node": "./dist/node/index.js",
     "./node/_loader": "./dist/node/_loader.js",
@@ -38,6 +39,7 @@
     "./runtime/dynamic": "./dist/runtime/dynamic.js",
     "./runtime/server": "./dist/runtime/server.js",
     "./runtime/types": "./dist/runtime/types.js",
+    "./satteri": "./dist/satteri/index.js",
     "./vite": "./dist/vite/index.js",
     "./webpack/mdx": "./dist/webpack/mdx.js",
     "./webpack/meta": "./dist/webpack/meta.js",
@@ -54,7 +56,6 @@
     "types:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@fumadocs/satteri": "workspace:*",
     "@mdx-js/mdx": "^3.1.1",
     "@standard-schema/spec": "^1.1.0",
     "chokidar": "^5.0.0",
@@ -81,6 +82,7 @@
     "@types/picomatch": "^4.0.3",
     "@types/react": "^19.2.17",
     "fumadocs-core": "workspace:*",
+    "@fumadocs/satteri": "workspace:*",
     "mdast-util-directive": "^3.1.0",
     "next": "^16.2.9",
     "react": "^19.2.7",
@@ -95,6 +97,7 @@
     "webpack": "^5.107.2"
   },
   "peerDependencies": {
+    "@fumadocs/satteri": "^0.1.0",
     "@types/mdast": "*",
     "@types/mdx": "*",
     "@types/react": "*",
@@ -103,9 +106,16 @@
     "next": "^15.3.0 || ^16.0.0",
     "react": "^19.2.0",
     "rolldown": "*",
+    "satteri": "^0.9.4",
     "vite": "7.x.x || 8.x.x"
   },
   "peerDependenciesMeta": {
+    "@fumadocs/satteri": {
+      "optional": true
+    },
+    "satteri": {
+      "optional": true
+    },
     "rolldown": {
       "optional": true
     },

--- a/packages/mdx/src/config/build-satteri.ts
+++ b/packages/mdx/src/config/build-satteri.ts
@@ -1,0 +1,63 @@
+import type { MdxCompileOptions } from 'satteri';
+import type { SatteriPresetOptions } from '@fumadocs/satteri';
+import { applySatteriPreset } from '@fumadocs/satteri';
+import type { BuildEnvironment, DocCollectionItem, LoadedConfig } from '@/config/build';
+
+const satteriOptionsCache = new WeakMap<
+  LoadedConfig,
+  Map<string, MdxCompileOptions | Promise<MdxCompileOptions>>
+>();
+
+export function getSatteriOptions(
+  config: LoadedConfig,
+  collection?: DocCollectionItem,
+  environment: BuildEnvironment = 'bundler',
+): MdxCompileOptions | Promise<MdxCompileOptions> {
+  let cache = satteriOptionsCache.get(config);
+  if (!cache) {
+    cache = new Map();
+    satteriOptionsCache.set(config, cache);
+  }
+
+  const key = collection ? `${environment}:${collection.name}` : environment;
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  let result: MdxCompileOptions | Promise<MdxCompileOptions>;
+
+  if (collection?.compiler === 'satteri') {
+    const opts = collection.satteriOptions;
+    if (typeof opts === 'function') {
+      result = (opts as (env: BuildEnvironment) => Promise<SatteriPresetOptions>)(environment).then(
+        (options) => applySatteriPreset(options)(environment),
+      );
+    } else if (opts) {
+      result = applySatteriPreset(opts as SatteriPresetOptions)(environment);
+    } else {
+      result = (async () => {
+        const optionsFn = config.global.satteriOptions;
+        const options =
+          typeof optionsFn === 'function'
+            ? await (optionsFn as () => Promise<SatteriPresetOptions>)()
+            : (optionsFn as SatteriPresetOptions | undefined);
+        return applySatteriPreset(options)(environment);
+      })();
+    }
+  } else if (collection) {
+    throw new Error(
+      `Collection "${collection.name}" uses the default MDX compiler. Use getMDXOptions() instead of getSatteriOptions().`,
+    );
+  } else {
+    result = (async () => {
+      const optionsFn = config.global.satteriOptions;
+      const options =
+        typeof optionsFn === 'function'
+          ? await (optionsFn as () => Promise<SatteriPresetOptions>)()
+          : (optionsFn as SatteriPresetOptions | undefined);
+      return applySatteriPreset(options)(environment);
+    })();
+  }
+
+  cache.set(key, result);
+  return result;
+}

--- a/packages/mdx/src/config/build.ts
+++ b/packages/mdx/src/config/build.ts
@@ -6,6 +6,9 @@ import type {
   GlobalConfig,
   MetaCollection,
 } from '@/config/define';
+import type { MdxCompileOptions } from 'satteri';
+import type { SatteriPresetOptions } from '@fumadocs/satteri';
+import { applySatteriPreset } from '@fumadocs/satteri';
 import picomatch from 'picomatch';
 import { applyMdxPreset } from '@/config/preset';
 import path from 'node:path';
@@ -19,6 +22,10 @@ export interface LoadedConfig {
     collection?: DocCollectionItem,
     environment?: BuildEnvironment,
   ): ProcessorOptions | Promise<ProcessorOptions>;
+  getSatteriOptions(
+    collection?: DocCollectionItem,
+    environment?: BuildEnvironment,
+  ): MdxCompileOptions | Promise<MdxCompileOptions>;
   workspaces: Record<
     string,
     {
@@ -142,6 +149,7 @@ export function buildConfig(config: Record<string, unknown>, cwd: string): Loade
   }
 
   const mdxOptionsCache = new Map<string, ProcessorOptions | Promise<ProcessorOptions>>();
+  const satteriOptionsCache = new Map<string, MdxCompileOptions | Promise<MdxCompileOptions>>();
   return {
     global: loaded,
     collections,
@@ -162,6 +170,12 @@ export function buildConfig(config: Record<string, unknown>, cwd: string): Loade
       if (cached) return cached;
       let result: ProcessorOptions | Promise<ProcessorOptions>;
 
+      if (collection?.compiler === 'satteri') {
+        throw new Error(
+          `Collection "${collection.name}" uses compiler: "satteri". Use getSatteriOptions() instead of getMDXOptions().`,
+        );
+      }
+
       if (collection?.mdxOptions) {
         const optionsFn = collection.mdxOptions;
         result = typeof optionsFn === 'function' ? optionsFn(environment) : optionsFn;
@@ -175,6 +189,44 @@ export function buildConfig(config: Record<string, unknown>, cwd: string): Loade
       }
 
       mdxOptionsCache.set(key, result);
+      return result;
+    },
+    getSatteriOptions(collection, environment = 'bundler') {
+      const key = collection ? `${environment}:${collection.name}` : environment;
+      const cached = satteriOptionsCache.get(key);
+      if (cached) return cached;
+      let result: MdxCompileOptions | Promise<MdxCompileOptions>;
+
+      if (collection?.compiler === 'satteri') {
+        const opts = collection.satteriOptions;
+        if (typeof opts === 'function') {
+          result = opts(environment).then((options: SatteriPresetOptions) =>
+            applySatteriPreset(options)(environment),
+          );
+        } else if (opts) {
+          result = applySatteriPreset(opts)(environment);
+        } else {
+          result = (async () => {
+            const optionsFn = this.global.satteriOptions;
+            const options = typeof optionsFn === 'function' ? await optionsFn() : optionsFn;
+            return applySatteriPreset(options)(environment);
+          })();
+        }
+      } else if (collection) {
+        throw new Error(
+          collection
+            ? `Collection "${collection.name}" uses the default MDX compiler. Use getMDXOptions() instead of getSatteriOptions().`
+            : 'getSatteriOptions() requires a collection with compiler: "satteri".',
+        );
+      } else {
+        result = (async () => {
+          const optionsFn = this.global.satteriOptions;
+          const options = typeof optionsFn === 'function' ? await optionsFn() : optionsFn;
+          return applySatteriPreset(options)(environment);
+        })();
+      }
+
+      satteriOptionsCache.set(key, result);
       return result;
     },
   };

--- a/packages/mdx/src/config/build.ts
+++ b/packages/mdx/src/config/build.ts
@@ -1,4 +1,3 @@
-import type { ProcessorOptions } from '@mdx-js/mdx';
 import type {
   AnyCollection,
   DocCollection,
@@ -6,12 +5,10 @@ import type {
   GlobalConfig,
   MetaCollection,
 } from '@/config/define';
-import type { MdxCompileOptions } from 'satteri';
-import type { SatteriPresetOptions } from '@fumadocs/satteri';
-import { applySatteriPreset } from '@fumadocs/satteri';
 import picomatch from 'picomatch';
 import { applyMdxPreset } from '@/config/preset';
 import path from 'node:path';
+import type { ProcessorOptions } from '@mdx-js/mdx';
 
 export type BuildEnvironment = 'bundler' | 'runtime';
 
@@ -22,10 +19,6 @@ export interface LoadedConfig {
     collection?: DocCollectionItem,
     environment?: BuildEnvironment,
   ): ProcessorOptions | Promise<ProcessorOptions>;
-  getSatteriOptions(
-    collection?: DocCollectionItem,
-    environment?: BuildEnvironment,
-  ): MdxCompileOptions | Promise<MdxCompileOptions>;
   workspaces: Record<
     string,
     {
@@ -149,7 +142,6 @@ export function buildConfig(config: Record<string, unknown>, cwd: string): Loade
   }
 
   const mdxOptionsCache = new Map<string, ProcessorOptions | Promise<ProcessorOptions>>();
-  const satteriOptionsCache = new Map<string, MdxCompileOptions | Promise<MdxCompileOptions>>();
   return {
     global: loaded,
     collections,
@@ -189,44 +181,6 @@ export function buildConfig(config: Record<string, unknown>, cwd: string): Loade
       }
 
       mdxOptionsCache.set(key, result);
-      return result;
-    },
-    getSatteriOptions(collection, environment = 'bundler') {
-      const key = collection ? `${environment}:${collection.name}` : environment;
-      const cached = satteriOptionsCache.get(key);
-      if (cached) return cached;
-      let result: MdxCompileOptions | Promise<MdxCompileOptions>;
-
-      if (collection?.compiler === 'satteri') {
-        const opts = collection.satteriOptions;
-        if (typeof opts === 'function') {
-          result = opts(environment).then((options: SatteriPresetOptions) =>
-            applySatteriPreset(options)(environment),
-          );
-        } else if (opts) {
-          result = applySatteriPreset(opts)(environment);
-        } else {
-          result = (async () => {
-            const optionsFn = this.global.satteriOptions;
-            const options = typeof optionsFn === 'function' ? await optionsFn() : optionsFn;
-            return applySatteriPreset(options)(environment);
-          })();
-        }
-      } else if (collection) {
-        throw new Error(
-          collection
-            ? `Collection "${collection.name}" uses the default MDX compiler. Use getMDXOptions() instead of getSatteriOptions().`
-            : 'getSatteriOptions() requires a collection with compiler: "satteri".',
-        );
-      } else {
-        result = (async () => {
-          const optionsFn = this.global.satteriOptions;
-          const options = typeof optionsFn === 'function' ? await optionsFn() : optionsFn;
-          return applySatteriPreset(options)(environment);
-        })();
-      }
-
-      satteriOptionsCache.set(key, result);
       return result;
     },
   };

--- a/packages/mdx/src/config/define-satteri.ts
+++ b/packages/mdx/src/config/define-satteri.ts
@@ -1,0 +1,30 @@
+import type { SatteriPresetOptions } from '@fumadocs/satteri';
+import type { BuildEnvironment } from '@/config/build';
+import type { DocCollectionBase, GlobalConfig } from '@/config/define';
+
+export type { SatteriPresetOptions };
+
+export interface DocCollectionSatteriTyped<
+  Schema extends import('@standard-schema/spec').StandardSchemaV1 = import('@standard-schema/spec').StandardSchemaV1,
+> extends DocCollectionBase<Schema> {
+  type: 'doc';
+  compiler: 'satteri';
+  satteriOptions?:
+    | SatteriPresetOptions
+    | ((environment: BuildEnvironment) => Promise<SatteriPresetOptions>);
+  mdxOptions?: never;
+}
+
+export interface SatteriGlobalConfig extends Omit<GlobalConfig, 'satteriOptions'> {
+  satteriOptions?: SatteriPresetOptions | (() => Promise<SatteriPresetOptions>);
+}
+
+export function defineSatteriConfig(config: SatteriGlobalConfig = {}): SatteriGlobalConfig {
+  return config;
+}
+
+export function defineSatteriCollections<
+  Schema extends import('@standard-schema/spec').StandardSchemaV1 = import('@standard-schema/spec').StandardSchemaV1,
+>(options: DocCollectionSatteriTyped<Schema>): DocCollectionSatteriTyped<Schema> {
+  return options;
+}

--- a/packages/mdx/src/config/define.ts
+++ b/packages/mdx/src/config/define.ts
@@ -1,11 +1,15 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { MDXPresetOptions } from '@/config/preset';
 import type { ProcessorOptions } from '@mdx-js/mdx';
-import type { SatteriPresetOptions } from '@fumadocs/satteri';
 import { metaSchema, pageSchema } from 'fumadocs-core/source/schema';
 import type { PostprocessOptions } from '@/loaders/mdx/remark-postprocess';
 import type { PluginOption } from '@/core';
 import type { BuildEnvironment } from './build';
+
+/** @see `fumadocs-mdx/config/satteri` for typed Sätteri preset options */
+export type SatteriPresetConfig =
+  | Record<string, unknown>
+  | ((environment: BuildEnvironment) => Promise<Record<string, unknown>>);
 
 export type CollectionSchema<Schema extends StandardSchemaV1, Context> =
   | Schema
@@ -25,7 +29,7 @@ export interface MetaCollection<
   schema?: CollectionSchema<Schema, { path: string; source: string }>;
 }
 
-interface DocCollectionBase<Schema extends StandardSchemaV1 = StandardSchemaV1>
+export interface DocCollectionBase<Schema extends StandardSchemaV1 = StandardSchemaV1>
   extends BaseCollection {
   postprocess?: Partial<PostprocessOptions>;
   async?: boolean;
@@ -56,8 +60,8 @@ export interface DocCollectionSatteri<
    * Sätteri compile options. When omitted, the global `satteriOptions` preset is used.
    */
   satteriOptions?:
-    | SatteriPresetOptions
-    | ((environment: BuildEnvironment) => Promise<SatteriPresetOptions>);
+    | SatteriPresetConfig
+    | ((environment: BuildEnvironment) => Promise<SatteriPresetConfig>);
 
   mdxOptions?: never;
 }
@@ -87,7 +91,7 @@ export interface GlobalConfig {
   /**
    * Configure global Sätteri options, used by `doc` collections with `compiler: "satteri"`.
    */
-  satteriOptions?: SatteriPresetOptions | (() => Promise<SatteriPresetOptions>);
+  satteriOptions?: SatteriPresetConfig | (() => Promise<SatteriPresetConfig>);
 
   workspaces?: Record<
     string,

--- a/packages/mdx/src/config/define.ts
+++ b/packages/mdx/src/config/define.ts
@@ -1,6 +1,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { MDXPresetOptions } from '@/config/preset';
 import type { ProcessorOptions } from '@mdx-js/mdx';
+import type { SatteriPresetOptions } from '@fumadocs/satteri';
 import { metaSchema, pageSchema } from 'fumadocs-core/source/schema';
 import type { PostprocessOptions } from '@/loaders/mdx/remark-postprocess';
 import type { PluginOption } from '@/core';
@@ -13,16 +14,7 @@ export type CollectionSchema<Schema extends StandardSchemaV1, Context> =
 export type AnyCollection = DocsCollection | DocCollection | MetaCollection;
 
 export interface BaseCollection {
-  /**
-   * Directory to scan
-   */
   dir: string;
-
-  /**
-   * what files to include/exclude (glob patterns)
-   *
-   * Include all files if not specified
-   */
   files?: string[];
 }
 
@@ -30,36 +22,49 @@ export interface MetaCollection<
   Schema extends StandardSchemaV1 = StandardSchemaV1,
 > extends BaseCollection {
   type: 'meta';
-
   schema?: CollectionSchema<Schema, { path: string; source: string }>;
 }
 
-export interface DocCollection<
-  Schema extends StandardSchemaV1 = StandardSchemaV1,
-> extends BaseCollection {
-  type: 'doc';
-
+interface DocCollectionBase<Schema extends StandardSchemaV1 = StandardSchemaV1>
+  extends BaseCollection {
   postprocess?: Partial<PostprocessOptions>;
+  async?: boolean;
+  dynamic?: boolean;
+  schema?: CollectionSchema<Schema, { path: string; source: string }>;
+}
+
+export interface DocCollectionMdx<
+  Schema extends StandardSchemaV1 = StandardSchemaV1,
+> extends DocCollectionBase<Schema> {
+  type: 'doc';
+  compiler?: 'mdx';
 
   /**
    * By defining a collection-level MDX options, **the default options & plugins will be removed**.
-   *
-   * See [`mdxOptions`](https://fumadocs.dev/docs/mdx/collections#mdxoptions) for details.
    */
   mdxOptions?: ProcessorOptions | ((environment: BuildEnvironment) => Promise<ProcessorOptions>);
-
-  /**
-   * Load files with async
-   */
-  async?: boolean;
-
-  /**
-   * Compile files on-demand
-   */
-  dynamic?: boolean;
-
-  schema?: CollectionSchema<Schema, { path: string; source: string }>;
+  satteriOptions?: never;
 }
+
+export interface DocCollectionSatteri<
+  Schema extends StandardSchemaV1 = StandardSchemaV1,
+> extends DocCollectionBase<Schema> {
+  type: 'doc';
+  compiler: 'satteri';
+
+  /**
+   * Sätteri compile options. When omitted, the global `satteriOptions` preset is used.
+   */
+  satteriOptions?:
+    | SatteriPresetOptions
+    | ((environment: BuildEnvironment) => Promise<SatteriPresetOptions>);
+
+  mdxOptions?: never;
+}
+
+export type DocCollection<Schema extends StandardSchemaV1 = StandardSchemaV1> =
+  | DocCollectionMdx<Schema>
+  | DocCollectionSatteri<Schema>;
 
 export interface DocsCollection<
   DocSchema extends StandardSchemaV1 = StandardSchemaV1,
@@ -67,7 +72,6 @@ export interface DocsCollection<
 > {
   type: 'docs';
   dir: string;
-
   docs: DocCollection<DocSchema>;
   meta: MetaCollection<MetaSchema>;
 }
@@ -76,9 +80,14 @@ export interface GlobalConfig {
   plugins?: PluginOption[];
 
   /**
-   * Configure global MDX options, will be used by all `doc` collections unless collection-level `mdxOptions` is specified.
+   * Configure global MDX options, used by `doc` collections with the default MDX compiler.
    */
   mdxOptions?: MDXPresetOptions | (() => Promise<MDXPresetOptions>);
+
+  /**
+   * Configure global Sätteri options, used by `doc` collections with `compiler: "satteri"`.
+   */
+  satteriOptions?: SatteriPresetOptions | (() => Promise<SatteriPresetOptions>);
 
   workspaces?: Record<
     string,
@@ -88,11 +97,6 @@ export interface GlobalConfig {
     }
   >;
 
-  /**
-   * specify a directory to access & store cache (disabled during development mode).
-   *
-   * The cache will never be updated, delete the cache folder to clean.
-   */
   experimentalBuildCache?: string;
 }
 
@@ -106,20 +110,14 @@ export function defineCollections<Schema extends StandardSchemaV1 = StandardSche
 export function defineCollections(
   options: DocCollection | MetaCollection,
 ): DocCollection | MetaCollection {
-  return options as any;
+  return options as DocCollection | MetaCollection;
 }
 
 export function defineDocs<
   DocSchema extends StandardSchemaV1 = typeof pageSchema,
   MetaSchema extends StandardSchemaV1 = typeof metaSchema,
 >(options: {
-  /**
-   * The content directory to scan files
-   *
-   *  @defaultValue 'content/docs'
-   */
   dir?: string;
-
   docs?: Omit<DocCollection<DocSchema>, 'dir' | 'type'>;
   meta?: Omit<MetaCollection<MetaSchema>, 'dir' | 'type'>;
 }): DocsCollection<DocSchema, MetaSchema> {
@@ -133,13 +131,13 @@ export function defineDocs<
       dir,
       schema: pageSchema as any,
       ...options?.docs,
-    }),
+    } as DocCollection<DocSchema>),
     meta: defineCollections({
       type: 'meta',
       dir,
       schema: metaSchema as any,
       ...options?.meta,
-    }),
+    } as MetaCollection<MetaSchema>),
   };
 }
 

--- a/packages/mdx/src/config/satteri/index.ts
+++ b/packages/mdx/src/config/satteri/index.ts
@@ -1,0 +1,2 @@
+export * from '@/config/define-satteri';
+export { getSatteriOptions } from '@/config/build-satteri';

--- a/packages/mdx/src/loaders/mdx/build-mdx.ts
+++ b/packages/mdx/src/loaders/mdx/build-mdx.ts
@@ -74,6 +74,20 @@ declare module 'vfile' {
 export async function buildMDX(
   core: Core,
   collection: DocCollectionItem | undefined,
+  options: BuildMDXOptions,
+): Promise<VFile> {
+  if (collection?.compiler === 'satteri') {
+    const { buildSatteriMDX } = await import('@/loaders/mdx/build-satteri-mdx');
+    const compiled = await buildSatteriMDX(core, collection, options);
+    return new VFile({ value: compiled.value, path: options.filePath });
+  }
+
+  return buildMdxWithProcessor(core, collection, options);
+}
+
+async function buildMdxWithProcessor(
+  core: Core,
+  collection: DocCollectionItem | undefined,
   { filePath, frontmatter, source, _compiler, environment, isDevelopment }: BuildMDXOptions,
 ): Promise<VFile> {
   const mdxOptions = await core.getConfig().getMDXOptions(collection, environment);

--- a/packages/mdx/src/loaders/mdx/build-mdx.ts
+++ b/packages/mdx/src/loaders/mdx/build-mdx.ts
@@ -77,7 +77,7 @@ export async function buildMDX(
   options: BuildMDXOptions,
 ): Promise<VFile> {
   if (collection?.compiler === 'satteri') {
-    const { buildSatteriMDX } = await import('@/loaders/mdx/build-satteri-mdx');
+    const { buildSatteriMDX } = await import('@/satteri/index');
     const compiled = await buildSatteriMDX(core, collection, options);
     return new VFile({ value: compiled.value, path: options.filePath });
   }

--- a/packages/mdx/src/loaders/mdx/build-satteri-mdx.ts
+++ b/packages/mdx/src/loaders/mdx/build-satteri-mdx.ts
@@ -7,6 +7,7 @@ import type { Core } from '@/core';
 import type { DocCollectionItem } from '@/config/build';
 import type { CompilerOptions } from '@/loaders/mdx/build-mdx';
 import type { PostprocessOptions } from '@/loaders/mdx/remark-postprocess';
+import { getSatteriOptions } from '@/config/build-satteri';
 import { compileMdx, queueDataExport, flattenNode } from '@fumadocs/satteri';
 import { defineMdastPlugin } from 'satteri';
 import { remarkIncludeSatteri } from '@/loaders/mdx/remark-include-satteri';
@@ -41,7 +42,7 @@ export async function buildSatteriMDX(
     isDevelopment,
   }: BuildSatteriMDXOptions,
 ): Promise<{ value: string }> {
-  const satteriOptions = await core.getConfig().getSatteriOptions(collection, environment);
+  const satteriOptions = await getSatteriOptions(core.getConfig(), collection, environment);
   const postprocess: PostprocessOptions = {
     _format: filePath.endsWith('.mdx') ? 'mdx' : 'md',
     ...collection?.postprocess,

--- a/packages/mdx/src/loaders/mdx/build-satteri-mdx.ts
+++ b/packages/mdx/src/loaders/mdx/build-satteri-mdx.ts
@@ -1,0 +1,93 @@
+import { pathToFileURL } from 'node:url';
+import type { StructuredData } from 'fumadocs-core/mdx-plugins';
+import type { TOCItemType } from 'fumadocs-core/toc';
+import type { FC } from 'react';
+import type { MDXProps } from 'mdx/types';
+import type { Core } from '@/core';
+import type { DocCollectionItem } from '@/config/build';
+import type { CompilerOptions } from '@/loaders/mdx/build-mdx';
+import type { PostprocessOptions } from '@/loaders/mdx/remark-postprocess';
+import { compileMdx, queueDataExport, flattenNode } from '@fumadocs/satteri';
+import { defineMdastPlugin } from 'satteri';
+import { remarkIncludeSatteri } from '@/loaders/mdx/remark-include-satteri';
+
+interface BuildSatteriMDXOptions {
+  filePath: string;
+  source: string;
+  frontmatter?: Record<string, unknown>;
+  environment: 'bundler' | 'runtime';
+  isDevelopment: boolean;
+  _compiler?: CompilerOptions;
+}
+
+export interface CompiledSatteriMDXProperties<Frontmatter = Record<string, unknown>> {
+  frontmatter: Frontmatter;
+  structuredData: StructuredData;
+  toc: TOCItemType[];
+  default: FC<MDXProps>;
+  _markdown?: string;
+  _mdast?: string;
+}
+
+export async function buildSatteriMDX(
+  core: Core,
+  collection: DocCollectionItem | undefined,
+  {
+    filePath,
+    frontmatter,
+    source,
+    _compiler,
+    environment,
+    isDevelopment,
+  }: BuildSatteriMDXOptions,
+): Promise<{ value: string }> {
+  const satteriOptions = await core.getConfig().getSatteriOptions(collection, environment);
+  const postprocess: PostprocessOptions = {
+    _format: filePath.endsWith('.mdx') ? 'mdx' : 'md',
+    ...collection?.postprocess,
+  };
+
+  const data: Record<string, unknown> = {
+    frontmatter,
+    _compiler,
+  };
+
+  const result = await compileMdx({
+    source,
+    filePath,
+    frontmatter,
+    isDevelopment,
+    environment,
+    options: {
+      ...satteriOptions,
+      fileURL: pathToFileURL(filePath),
+      data,
+      mdastPlugins: [
+        remarkIncludeSatteri({ cwd: collection?.cwd }),
+        ...(satteriOptions.mdastPlugins ?? []),
+        postprocessPlugin(postprocess),
+      ],
+    },
+  });
+
+  return { value: result.code };
+}
+
+function postprocessPlugin(options: PostprocessOptions) {
+  return () =>
+    defineMdastPlugin({
+      name: 'remark-postprocess',
+      heading(node, ctx) {
+        const frontmatter = (ctx.data.frontmatter ??= {}) as Record<string, unknown>;
+        if (!frontmatter.title && node.depth === 1) {
+          frontmatter.title = flattenNode(node);
+        }
+      },
+      link(node, ctx) {
+        if (!options.extractLinkReferences) return;
+        const refs = (ctx.data.extractedReferences ??= []) as { href: string }[];
+        refs.push({ href: node.url });
+        queueDataExport(ctx.data, 'extractedReferences', refs);
+      },
+    });
+}

--- a/packages/mdx/src/loaders/mdx/remark-include-satteri.ts
+++ b/packages/mdx/src/loaders/mdx/remark-include-satteri.ts
@@ -1,0 +1,107 @@
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { defineMdastPlugin, mdxToMdast, markdownToMdast } from 'satteri';
+import type { MdastVisitorContext } from 'satteri';
+import { frontmatter } from 'fumadocs-core/content/md/frontmatter';
+import { flattenNode } from '@fumadocs/satteri';
+import type { Code, RootContent } from 'mdast';
+import type { CompilerOptions } from '@/loaders/mdx/build-mdx';
+
+export function remarkIncludeSatteri({ cwd }: { cwd?: string } = {}) {
+  return defineMdastPlugin({
+    name: 'remark-include',
+    async mdxJsxFlowElement(node, ctx) {
+      if (node.name !== 'include') return;
+      await replaceInclude(node, ctx, cwd);
+    },
+    async containerDirective(node, ctx) {
+      if (node.name !== 'include') return;
+      await replaceInclude(node, ctx, cwd);
+    },
+  });
+}
+
+async function replaceInclude(node: RootContent, ctx: MdastVisitorContext, cwd?: string) {
+  const specifier = flattenNode(node).trim();
+  if (!specifier) return;
+
+  const parent = ctx.parent(node);
+  const index = ctx.indexOf(node);
+  if (!parent || index === undefined) return;
+
+  const { file: relativePath, section } = parseSpecifier(specifier);
+  const baseDir = ctx.fileURL ? path.dirname(fileURLToPath(ctx.fileURL)) : cwd ?? process.cwd();
+  const targetPath = path.resolve(baseDir, relativePath);
+
+  const compiler = ctx.data._compiler as CompilerOptions | undefined;
+  compiler?.addDependency(targetPath);
+
+  const ext = path.extname(targetPath);
+  let replacement: RootContent | RootContent[];
+
+  if (ext !== '.md' && ext !== '.mdx') {
+    const content = await fsRead(targetPath);
+    replacement = {
+      type: 'code',
+      lang: ext.slice(1),
+      value: content,
+    } satisfies Code;
+  } else {
+    const content = await fsRead(targetPath);
+    const parsed = frontmatter(content);
+    const parse = ext === '.mdx' ? mdxToMdast : markdownToMdast;
+    const tree = parse(parsed.content, {
+      features: { gfm: true, directive: true, headingAttributes: true },
+    }) as { children: RootContent[] };
+
+    if (section) {
+      const extracted = extractSection(tree.children, section);
+      if (!extracted) {
+        throw new Error(`Cannot find section ${section} in ${targetPath}`);
+      }
+      replacement = extracted;
+    } else {
+      replacement = tree.children;
+    }
+  }
+
+  if (Array.isArray(replacement)) {
+    const children = [...parent.children];
+    children.splice(index, 1, ...replacement);
+    ctx.setProperty(parent, 'children', children);
+  } else {
+    ctx.replaceNode(node, replacement);
+  }
+}
+
+async function fsRead(file: string) {
+  const { readFile } = await import('node:fs/promises');
+  return readFile(file, 'utf-8');
+}
+
+function parseSpecifier(specifier: string) {
+  const idx = specifier.lastIndexOf('#');
+  if (idx === -1) return { file: specifier };
+  return { file: specifier.slice(0, idx), section: specifier.slice(idx + 1) };
+}
+
+function extractSection(children: RootContent[], section: string): RootContent[] | undefined {
+  let nodes: RootContent[] | undefined;
+  let capturing = false;
+
+  for (const node of children) {
+    if (node.type === 'heading') {
+      if (capturing) break;
+      const id = (node.data as { hProperties?: { id?: string } } | undefined)?.hProperties?.id;
+      if (id === section) {
+        capturing = true;
+        nodes = [node];
+      }
+      continue;
+    }
+
+    if (capturing) nodes?.push(node);
+  }
+
+  return nodes;
+}

--- a/packages/mdx/src/satteri/index.ts
+++ b/packages/mdx/src/satteri/index.ts
@@ -1,0 +1,3 @@
+export { buildSatteriMDX, type CompiledSatteriMDXProperties } from '@/loaders/mdx/build-satteri-mdx';
+export { getSatteriOptions } from '@/config/build-satteri';
+export * from '@/config/define-satteri';

--- a/packages/mdx/test/satteri.test.ts
+++ b/packages/mdx/test/satteri.test.ts
@@ -1,0 +1,101 @@
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { expect, test } from 'vitest';
+import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins/rehype-code';
+import { defineCollections, defineConfig } from '@/config';
+import { buildConfig, type DocCollectionItem } from '@/config/build';
+import { getSatteriOptions } from '@/config/build-satteri';
+import { createCore } from '@/core';
+import { buildMDX } from '@/loaders/mdx/build-mdx';
+
+const baseDir = path.dirname(fileURLToPath(import.meta.url));
+
+test('satteri compiler resolves preset options', async () => {
+  const config = buildConfig(
+    {
+      docs: defineCollections({
+        type: 'doc',
+        compiler: 'satteri',
+        dir: baseDir,
+      }),
+      default: defineConfig({
+        satteriOptions: {
+          rehypeCodeOptions: false,
+        },
+      }),
+    },
+    process.cwd(),
+  );
+
+  const options = await getSatteriOptions(config, config.collections.get('docs') as DocCollectionItem);
+  expect(options.features?.gfm).toBe(true);
+  expect(options.mdastPlugins?.length).toBeGreaterThan(0);
+});
+
+test('buildMDX with satteri compiler', async () => {
+  const core = createCore({
+    configPath: 'source.config.ts',
+    environment: 'test',
+    outDir: '.source',
+  });
+
+  const config = buildConfig(
+    {
+      docs: defineCollections({
+        type: 'doc',
+        compiler: 'satteri',
+        dir: baseDir,
+        satteriOptions: {
+          rehypeCodeOptions: {
+            ...rehypeCodeDefaultOptions,
+            lazy: false,
+            langs: ['js'],
+          },
+        },
+      }),
+    },
+    process.cwd(),
+  );
+
+  await core.init({ config });
+
+  const collection = config.collections.get('docs') as DocCollectionItem;
+  const compiled = await buildMDX(core, collection, {
+    filePath: path.join(baseDir, 'satteri-fixture.mdx'),
+    source: `---
+title: Satteri test
+---
+
+# Hello Satteri
+
+\`\`\`js
+export const x = 1
+\`\`\`
+`,
+    frontmatter: { title: 'Satteri test' },
+    environment: 'bundler',
+    isDevelopment: false,
+  });
+
+  expect(compiled.value).toContain('export const frontmatter');
+  expect(compiled.value).toContain('export const structuredData');
+  expect(compiled.value).toContain('export const toc');
+  expect(compiled.value).toContain('shiki');
+  expect(compiled.value).toContain('Hello Satteri');
+});
+
+test('getMDXOptions rejects satteri collections', async () => {
+  const config = buildConfig(
+    {
+      docs: defineCollections({
+        type: 'doc',
+        compiler: 'satteri',
+        dir: baseDir,
+      }),
+    },
+    process.cwd(),
+  );
+
+  const collection = config.collections.get('docs') as DocCollectionItem;
+  expect(() => config.getMDXOptions(collection)).toThrow(/getSatteriOptions/);
+});

--- a/packages/mdx/tsconfig.json
+++ b/packages/mdx/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "tsconfig/base.json",
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@fumadocs/satteri": ["../satteri/dist/index.d.ts"],
+      "@fumadocs/satteri/*": ["../satteri/dist/*"]
     },
     "types": ["@types/node", "@types/mdx"],
     "jsx": "react-jsx",

--- a/packages/mdx/tsdown.config.ts
+++ b/packages/mdx/tsdown.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   entry: [
     './src/{index,bin}.ts',
     './src/{config,next,vite,bun,rolldown}/index.ts',
+    './src/config/satteri/index.ts',
+    './src/satteri/index.ts',
     './src/webpack/{mdx,meta}.ts',
     './src/node/{index,_loader,loader}.ts',
     './src/runtime/*.{ts,tsx}',
@@ -20,6 +22,6 @@ export default defineConfig({
   },
   deps: {
     onlyBundle: ['@fumadocs/vite'],
-    neverBundle: ['webpack', 'bun', /^node:/],
+    neverBundle: ['webpack', 'bun', /^node:/, '@fumadocs/satteri', 'satteri'],
   },
 });

--- a/packages/satteri/package.json
+++ b/packages/satteri/package.json
@@ -50,9 +50,7 @@
     "hast-util-to-estree": "^3.1.3",
     "image-size": "^2.0.2",
     "npm-to-yarn": "^3.0.1",
-    "satteri": "^0.9.4",
-    "unified": "^11.0.5",
-    "vfile": "^6.0.3"
+    "satteri": "^0.9.4"
   },
   "devDependencies": {
     "@types/estree": "^1.0.9",

--- a/packages/satteri/package.json
+++ b/packages/satteri/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@fumadocs/satteri",
+  "version": "0.1.0",
+  "description": "Fumadocs plugins and presets for Sätteri",
+  "keywords": [
+    "Docs",
+    "fumadocs",
+    "satteri",
+    "mdx"
+  ],
+  "homepage": "https://fumadocs.dev",
+  "license": "MIT",
+  "author": "Fuma Nama",
+  "repository": "github:fuma-nama/fumadocs",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./preset": {
+      "types": "./dist/preset.d.ts",
+      "import": "./dist/preset.js"
+    },
+    "./compile": {
+      "types": "./dist/compile.d.ts",
+      "import": "./dist/compile.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "clean": "rimraf dist",
+    "dev": "tsdown --watch",
+    "lint": "oxlint .",
+    "test": "vitest run",
+    "types:check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "estree-util-to-js": "^2.0.0",
+    "estree-util-value-to-estree": "^3.5.0",
+    "fumadocs-core": "workspace:*",
+    "github-slugger": "^2.0.0",
+    "hast-util-to-estree": "^3.1.3",
+    "image-size": "^2.0.2",
+    "npm-to-yarn": "^3.0.1",
+    "satteri": "^0.9.4",
+    "unified": "^11.0.5",
+    "vfile": "^6.0.3"
+  },
+  "devDependencies": {
+    "@types/estree": "^1.0.9",
+    "@types/estree-jsx": "^1.0.5",
+    "@types/hast": "^3.0.4",
+    "@types/mdast": "^4.0.4",
+    "@types/node": "26.0.0",
+    "mdast-util-mdx": "^3.0.0",
+    "shiki": "^3.0.0",
+    "tsconfig": "workspace:*",
+    "tsdown": "0.22.3",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  },
+  "peerDependencies": {
+    "@types/hast": "*",
+    "@types/mdast": "*",
+    "fumadocs-core": "^16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/hast": {
+      "optional": true
+    },
+    "@types/mdast": {
+      "optional": true
+    }
+  }
+}

--- a/packages/satteri/src/compile.ts
+++ b/packages/satteri/src/compile.ts
@@ -1,0 +1,91 @@
+import { mdxToJs, type MdxCompileOptions, type MdastPluginInput, type HastPluginInput, type Frontmatter } from 'satteri';
+import { pathToFileURL } from 'node:url';
+import { appendExports, queueDataExport } from '@/inject-exports';
+
+export interface CompileMdxOptions {
+  source: string;
+  filePath: string;
+  frontmatter?: Record<string, unknown>;
+  isDevelopment?: boolean;
+  environment?: 'bundler' | 'runtime';
+  options: MdxCompileOptions;
+}
+
+export interface CompileMdxResult {
+  code: string;
+  data: MdxCompileOptions['data'];
+  frontmatter: Frontmatter | null;
+}
+
+function resolvePlugins<T extends MdastPluginInput | HastPluginInput>(plugins: T[] | undefined): T[] {
+  if (!plugins) return [];
+  return plugins.map((plugin) => (typeof plugin === 'function' ? (plugin() as T) : plugin));
+}
+
+export async function compileMdx({
+  source,
+  filePath,
+  frontmatter,
+  isDevelopment = false,
+  environment = 'bundler',
+  options,
+}: CompileMdxOptions): Promise<CompileMdxResult> {
+  const data = options.data ?? {};
+  if (frontmatter) data.frontmatter = frontmatter;
+
+  const mdastPlugins = resolvePlugins(options.mdastPlugins as MdastPluginInput[] | undefined);
+  const hastPlugins = await Promise.all(
+    (options.hastPlugins ?? []).map(async (plugin) => {
+      const resolved = typeof plugin === 'function' ? plugin() : plugin;
+      return resolved instanceof Promise ? await resolved : resolved;
+    }),
+  );
+
+  const result = await mdxToJs(source, {
+    ...options,
+    development: isDevelopment,
+    outputFormat: environment === 'runtime' ? 'function-body' : options.outputFormat,
+    fileURL: options.fileURL ?? pathToFileURL(filePath),
+    data,
+    mdastPlugins,
+    hastPlugins,
+    features: {
+      gfm: true,
+      frontmatter: false,
+      directive: true,
+      ...options.features,
+    },
+  });
+
+  const outData = result.data as typeof data;
+  if (outData.frontmatter) {
+    queueDataExport(outData, 'frontmatter', outData.frontmatter);
+  }
+
+  let code = appendExports(result.code, outData);
+
+  const imports = outData._imageImports as { type: string }[] | undefined;
+  if (imports?.length) {
+    const importCode = imports
+      .map((node) => {
+        const estree = (node as { data?: { estree?: { body: unknown[] } } }).data?.estree;
+        if (!estree) return '';
+        const decl = estree.body[0] as {
+          type: string;
+          source: { value: string };
+          specifiers: { local: { name: string } }[];
+        };
+        if (decl.type !== 'ImportDeclaration') return '';
+        return `import ${decl.specifiers[0]!.local.name} from ${JSON.stringify(decl.source.value)};`;
+      })
+      .filter(Boolean)
+      .join('\n');
+    code = `${importCode}\n${code}`;
+  }
+
+  return {
+    code,
+    data: outData,
+    frontmatter: result.frontmatter,
+  };
+}

--- a/packages/satteri/src/index.ts
+++ b/packages/satteri/src/index.ts
@@ -1,0 +1,47 @@
+export {
+  defineMdastPlugin,
+  defineHastPlugin,
+  mdxToJs,
+  markdownToHtml,
+  evaluate,
+  markdownToMdast,
+  mdxToMdast,
+} from 'satteri';
+
+export type {
+  CompileOptions,
+  MdxCompileOptions,
+  MdxOnlyOptions,
+  MdastPluginInput,
+  HastPluginInput,
+  Features,
+  Frontmatter,
+  MarkdownToHtmlResult,
+  MdxToJsResult,
+} from 'satteri';
+
+export { applySatteriPreset } from '@/preset';
+export type { DefaultSatteriOptions, SatteriPresetOptions } from '@/preset';
+export { compileMdx } from '@/compile';
+export type { CompileMdxOptions, CompileMdxResult } from '@/compile';
+
+export { remarkHeading, type RemarkHeadingOptions } from '@/remark-heading';
+export { remarkStructure, type StructureOptions } from '@/remark-structure';
+export type { StructuredData } from '@/remark-structure';
+export { remarkImage, type RemarkImageOptions } from '@/remark-image';
+export { remarkCodeTab, type RemarkCodeTabOptions } from '@/remark-code-tab';
+export { remarkNpm, type RemarkNpmOptions } from '@/remark-npm';
+export { remarkBlockId, type RemarkBlockIdOptions } from '@/remark-block-id';
+export { remarkAdmonition, type RemarkAdmonitionOptions } from '@/remark-admonition';
+export {
+  remarkDirectiveAdmonition,
+  type RemarkDirectiveAdmonitionOptions,
+} from '@/remark-directive-admonition';
+export { remarkSteps, type RemarkStepsOptions } from '@/remark-steps';
+export { remarkMdxMermaid, type RemarkMdxMermaidOptions } from '@/remark-mdx-mermaid';
+export { remarkFeedbackBlock, type RemarkFeedbackBlockOptions } from '@/remark-feedback-block';
+export { rehypeToc, type RehypeTocOptions } from '@/rehype-toc';
+export { rehypeCode, type RehypeCodeOptions } from '@/rehype-code';
+
+export { flattenNode, handleTag } from '@/utils';
+export { appendExports, queueDataExport, queueTocJsxExport } from '@/inject-exports';

--- a/packages/satteri/src/inject-exports.ts
+++ b/packages/satteri/src/inject-exports.ts
@@ -1,0 +1,67 @@
+import { toEstree } from 'hast-util-to-estree';
+import type { Element } from 'hast';
+import type { JSXElement } from 'estree-jsx';
+import type { Data } from 'satteri';
+
+export interface TocJsxExportItem {
+  title: Element;
+  url: string;
+  depth: number;
+  _step?: number;
+}
+
+export function serializeValueExport(name: string, value: unknown): string {
+  return `export const ${name} = ${JSON.stringify(value)};`;
+}
+
+export function serializeTocJsxExport(name: string, items: TocJsxExportItem[]): string {
+  const esmItems: {
+    title: JSXElement;
+    url: string;
+    depth: number;
+    _step?: number;
+  }[] = [];
+
+  for (const item of items) {
+    const root = toEstree(item.title, {
+      elementAttributeNameCase: 'react',
+      stylePropertyNameCase: 'dom',
+    }).body[0];
+
+    if (root.type === 'ExpressionStatement' && root.expression.type === 'JSXElement') {
+      esmItems.push({ ...item, title: root.expression });
+    }
+  }
+
+  return `export const ${name} = ${JSON.stringify(esmItems, null, 0)};`;
+}
+
+export function appendExports(
+  code: string,
+  data: Data & {
+    _exports?: string[];
+  },
+): string {
+  const lines = data._exports ?? [];
+  if (lines.length === 0) return code;
+
+  return `${code.trimEnd()}\n${lines.join('\n')}\n`;
+}
+
+export function queueDataExport(
+  data: Data & { _exports?: string[] },
+  name: string,
+  value: unknown,
+): void {
+  data._exports ??= [];
+  data._exports.push(serializeValueExport(name, value));
+}
+
+export function queueTocJsxExport(
+  data: Data & { _exports?: string[] },
+  name: string,
+  items: TocJsxExportItem[],
+): void {
+  data._exports ??= [];
+  data._exports.push(serializeTocJsxExport(name, items));
+}

--- a/packages/satteri/src/preset.ts
+++ b/packages/satteri/src/preset.ts
@@ -1,0 +1,143 @@
+import { defineMdastPlugin, type MdastPluginInput } from 'satteri';
+import type {
+  HastPluginInput,
+  MdxCompileOptions,
+  MdxOnlyOptions,
+} from 'satteri';
+import type { BuildEnvironment } from '@/types';
+import { remarkHeading, type RemarkHeadingOptions } from '@/remark-heading';
+import { remarkImage, type RemarkImageOptions } from '@/remark-image';
+import { remarkCodeTab, type RemarkCodeTabOptions } from '@/remark-code-tab';
+import { remarkNpm, type RemarkNpmOptions } from '@/remark-npm';
+import { remarkStructure, type StructureOptions } from '@/remark-structure';
+import { rehypeCode, type RehypeCodeOptions } from '@/rehype-code';
+import { rehypeToc } from '@/rehype-toc';
+import { queueDataExport } from '@/inject-exports';
+
+type ResolvePlugins<T> = T[] | ((plugins: T[]) => T[]);
+
+export type DefaultSatteriOptions = Omit<MdxCompileOptions, 'mdastPlugins' | 'hastPlugins'> & {
+  mdastPlugins?: ResolvePlugins<MdastPluginInput>;
+  hastPlugins?: ResolvePlugins<HastPluginInput>;
+  valueToExport?: string[];
+  remarkStructureOptions?: StructureOptions | false;
+  remarkHeadingOptions?: RemarkHeadingOptions;
+  remarkImageOptions?: RemarkImageOptions | false;
+  remarkCodeTabOptions?: RemarkCodeTabOptions | false;
+  remarkNpmOptions?: RemarkNpmOptions | false;
+  rehypeCodeOptions?: RehypeCodeOptions | false;
+};
+
+export type SatteriPresetOptions =
+  | ({ preset?: 'fumadocs' } & DefaultSatteriOptions)
+  | ({
+      preset: 'minimal';
+    } & MdxOnlyOptions &
+      Pick<MdxCompileOptions, 'mdastPlugins' | 'hastPlugins' | 'features' | 'data'>);
+
+function pluginOption<T>(
+  def: (plugins: T[]) => (T | false)[],
+  options: ResolvePlugins<T> = [],
+): T[] {
+  const list = def(Array.isArray(options) ? options : []).filter(Boolean) as T[];
+  if (typeof options === 'function') return options(list);
+  return list;
+}
+
+function wrapMdastFactory<T>(
+  factory: (options?: T) => MdastPluginInput | (() => MdastPluginInput),
+  options?: T,
+): MdastPluginInput {
+  const plugin = factory(options);
+  return typeof plugin === 'function' ? plugin : plugin;
+}
+
+function wrapHastFactory<T>(
+  factory: (
+    options?: T,
+  ) => HastPluginInput | Promise<HastPluginInput> | (() => HastPluginInput | Promise<HastPluginInput>),
+  options?: T,
+): HastPluginInput {
+  return async () => {
+    const plugin = factory(options);
+    const resolved = plugin instanceof Promise ? await plugin : plugin;
+    return typeof resolved === 'function' ? await resolved() : resolved;
+  };
+}
+
+export function applySatteriPreset(
+  options: SatteriPresetOptions = {},
+): (environment: BuildEnvironment) => Promise<MdxCompileOptions> {
+  return async (environment = 'bundler') => {
+    if (options.preset === 'minimal') return options;
+
+    const {
+      valueToExport = [],
+      rehypeCodeOptions,
+      remarkImageOptions,
+      remarkHeadingOptions,
+      remarkStructureOptions,
+      remarkCodeTabOptions,
+      remarkNpmOptions,
+      mdastPlugins,
+      hastPlugins,
+      features,
+      ...rest
+    } = options;
+
+    const resolvedMdast = pluginOption<MdastPluginInput>(
+      (plugins) => [
+        wrapMdastFactory(remarkHeading, {
+          generateToc: false,
+          ...remarkHeadingOptions,
+        }),
+        remarkImageOptions !== false && wrapMdastFactory(remarkImage, remarkImageOptions),
+        remarkCodeTabOptions !== false && wrapMdastFactory(remarkCodeTab, remarkCodeTabOptions),
+        remarkNpmOptions !== false && wrapMdastFactory(remarkNpm, remarkNpmOptions),
+        ...plugins,
+        remarkStructureOptions !== false &&
+          wrapMdastFactory(remarkStructure, {
+            exportAs: 'structuredData',
+            ...remarkStructureOptions,
+          }),
+        valueToExport.length > 0 && valueExportPlugin(valueToExport),
+      ],
+      mdastPlugins,
+    );
+
+    const resolvedHast = pluginOption<HastPluginInput>(
+      (plugins) => [
+        rehypeCodeOptions !== false && wrapHastFactory(rehypeCode, rehypeCodeOptions),
+        ...plugins,
+        wrapHastFactory(rehypeToc),
+      ],
+      hastPlugins,
+    );
+
+    return {
+      ...rest,
+      outputFormat: environment === 'runtime' ? 'function-body' : rest.outputFormat,
+      features: {
+        gfm: true,
+        directive: true,
+        ...features,
+      },
+      mdastPlugins: resolvedMdast,
+      hastPlugins: resolvedHast,
+    };
+  };
+}
+
+function valueExportPlugin(names: string[]): MdastPluginInput {
+  return () =>
+    defineMdastPlugin({
+      name: 'value-to-export',
+      paragraph(_node, ctx) {
+        for (const name of names) {
+          if (name in ctx.data) {
+            queueDataExport(ctx.data, name, ctx.data[name]);
+          }
+        }
+      },
+    });
+}

--- a/packages/satteri/src/rehype-code.ts
+++ b/packages/satteri/src/rehype-code.ts
@@ -1,14 +1,40 @@
 import { defineHastPlugin } from 'satteri';
-import type { Element, Root } from 'hast';
-import type { Processor } from 'unified';
-import type { VFile } from 'vfile';
-import { rehypeCode as unifiedRehypeCode, type RehypeCodeOptions } from 'fumadocs-core/mdx-plugins/rehype-code';
+import type { Element, Root, RootContent } from 'hast';
+import {
+  rehypeCode as createRehypeCodeTransformer,
+  type RehypeCodeOptions,
+} from 'fumadocs-core/mdx-plugins/rehype-code';
 
 export type { RehypeCodeOptions } from 'fumadocs-core/mdx-plugins/rehype-code';
 
+function unwrapReplacement(node: RootContent | Root): RootContent | RootContent[] {
+  if (node.type === 'root') return node.children;
+  return node;
+}
+
+function replaceHighlightedNode(
+  element: Element,
+  next: RootContent | Root | undefined,
+  ctx: { replaceNode: (node: Element, newNode: RootContent) => void; insertAfter: (node: RootContent, newNode: RootContent | RootContent[]) => void },
+) {
+  if (!next) return;
+
+  const replacement = unwrapReplacement(next);
+  if (Array.isArray(replacement)) {
+    if (replacement.length === 0) return;
+    ctx.replaceNode(element, replacement[0]);
+    if (replacement.length > 1) ctx.insertAfter(replacement[0], replacement.slice(1));
+    return;
+  }
+
+  ctx.replaceNode(element, replacement);
+}
+
 export function rehypeCode(options?: Partial<RehypeCodeOptions>) {
+  const runBlock = createRehypeCodeTransformer.call({} as never, options);
+
   return async () => {
-    const transformer = unifiedRehypeCode.call({} as Processor, options);
+    const inline = options?.inline;
 
     return defineHastPlugin({
       name: 'rehype-code',
@@ -16,18 +42,15 @@ export function rehypeCode(options?: Partial<RehypeCodeOptions>) {
         filter: ['pre', 'code'],
         async visit(node, ctx) {
           const element = node as Element;
-          if (element.tagName !== 'pre' && !(element.tagName === 'code' && options?.inline)) {
+          if (element.tagName !== 'pre' && !(element.tagName === 'code' && inline)) {
             return;
           }
 
           const tree: Root = { type: 'root', children: [structuredClone(element)] };
-          await transformer(tree, {} as VFile, () => undefined);
-          const next = tree.children[0];
-          if (next) ctx.replaceNode(element, next);
+          await runBlock(tree, {} as never, () => undefined);
+          replaceHighlightedNode(element, tree.children[0], ctx);
         },
       },
     });
   };
 }
-
-// ponytail: delegates highlighting to fumadocs-core's unified shiki on a one-node hast subtree

--- a/packages/satteri/src/rehype-code.ts
+++ b/packages/satteri/src/rehype-code.ts
@@ -1,0 +1,33 @@
+import { defineHastPlugin } from 'satteri';
+import type { Element, Root } from 'hast';
+import type { Processor } from 'unified';
+import type { VFile } from 'vfile';
+import { rehypeCode as unifiedRehypeCode, type RehypeCodeOptions } from 'fumadocs-core/mdx-plugins/rehype-code';
+
+export type { RehypeCodeOptions } from 'fumadocs-core/mdx-plugins/rehype-code';
+
+export function rehypeCode(options?: Partial<RehypeCodeOptions>) {
+  return async () => {
+    const transformer = unifiedRehypeCode.call({} as Processor, options);
+
+    return defineHastPlugin({
+      name: 'rehype-code',
+      element: {
+        filter: ['pre', 'code'],
+        async visit(node, ctx) {
+          const element = node as Element;
+          if (element.tagName !== 'pre' && !(element.tagName === 'code' && options?.inline)) {
+            return;
+          }
+
+          const tree: Root = { type: 'root', children: [structuredClone(element)] };
+          await transformer(tree, {} as VFile, () => undefined);
+          const next = tree.children[0];
+          if (next) ctx.replaceNode(element, next);
+        },
+      },
+    });
+  };
+}
+
+// ponytail: delegates highlighting to fumadocs-core's unified shiki on a one-node hast subtree

--- a/packages/satteri/src/rehype-toc.ts
+++ b/packages/satteri/src/rehype-toc.ts
@@ -1,0 +1,80 @@
+import { defineHastPlugin, type HastPluginDefinition } from 'satteri';
+import type { Element } from 'hast';
+import { handleTag } from '@/utils';
+import { queueTocJsxExport, type TocJsxExportItem } from '@/inject-exports';
+
+export interface RehypeTocOptions {
+  exportToc?:
+    | boolean
+    | { as: 'data' }
+    | {
+        as: 'esm';
+        name: string;
+      };
+}
+
+const TocOnlyTag = '[toc]';
+const NoTocTag = '[!toc]';
+const HeadingTags = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+export function rehypeToc({ exportToc = true }: RehypeTocOptions = {}): HastPluginDefinition | (() => HastPluginDefinition) {
+  if (exportToc === false) {
+    return defineHastPlugin({ name: 'rehype-toc' });
+  }
+
+  const resolved = exportToc === true ? { as: 'esm' as const, name: 'toc' } : exportToc;
+
+  return () => {
+    const items: TocJsxExportItem[] = [];
+
+    return defineHastPlugin({
+      name: 'rehype-toc',
+      element: {
+        filter: [...HeadingTags],
+        visit(node, ctx) {
+          const element = node as Element;
+          if (element.children.length === 0) return;
+
+          const id = element.properties.id;
+          if (typeof id !== 'string') return;
+
+          let isTocOnly = false;
+          const last = element.children[element.children.length - 1];
+          if (last?.type === 'text') {
+            const noToc = handleTag(last.value, NoTocTag);
+            if (noToc !== false) {
+              ctx.setProperty(last, 'value', noToc);
+              return;
+            }
+
+            const tocOnly = handleTag(last.value, TocOnlyTag);
+            if (tocOnly !== false) {
+              isTocOnly = true;
+              ctx.setProperty(last, 'value', tocOnly);
+            }
+          }
+
+          items.push({
+            title: element,
+            depth: Number(element.tagName[1]),
+            url: `#${id}`,
+            _step:
+              typeof element.properties['data-fd-step'] === 'number'
+                ? element.properties['data-fd-step']
+                : undefined,
+          });
+
+          if (isTocOnly) ctx.removeNode(element);
+
+          if (resolved.as === 'esm') {
+            queueTocJsxExport(ctx.data, resolved.name, items);
+          } else {
+            ctx.data.rehypeToc = items;
+          }
+        },
+      },
+    });
+  };
+}
+
+export type { TocJsxExportItem as RehypeTOCItemType } from '@/inject-exports';

--- a/packages/satteri/src/remark-admonition.ts
+++ b/packages/satteri/src/remark-admonition.ts
@@ -1,0 +1,94 @@
+import { defineMdastPlugin } from 'satteri';
+import { flattenNode } from '@/utils';
+import type { MdastNode } from 'satteri';
+
+export interface RemarkAdmonitionOptions {
+  tag?: string;
+  typeMap?: Record<string, string>;
+}
+
+export function remarkAdmonition(options: RemarkAdmonitionOptions = {}) {
+  const tag = options.tag ?? ':::';
+  const typeMap = options.typeMap ?? {
+    info: 'info',
+    warn: 'warn',
+    note: 'info',
+    tip: 'info',
+    warning: 'warn',
+    danger: 'error',
+  };
+
+  function replaceNodes(nodes: MdastNode[]) {
+    if (nodes.length === 0) return;
+
+    let open = -1;
+    const attributes: { type: 'mdxJsxAttribute'; name: string; value: string }[] = [];
+    let hasIntercept = false;
+
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      if (node.type !== 'paragraph') continue;
+
+      const text = flattenNode(node);
+      const typeName = Object.keys(typeMap).find((type) => text.startsWith(`${tag}${type}`));
+      if (typeName) {
+        if (open !== -1) {
+          hasIntercept = true;
+          continue;
+        }
+
+        open = i;
+        attributes.push({
+          type: 'mdxJsxAttribute',
+          name: 'type',
+          value: typeMap[typeName]!,
+        });
+
+        const meta = text.slice(`${tag}${typeName}`.length);
+        if (meta.startsWith('[') && meta.endsWith(']')) {
+          attributes.push({
+            type: 'mdxJsxAttribute',
+            name: 'title',
+            value: meta.slice(1, -1),
+          });
+        }
+      }
+
+      if (open !== -1 && text === tag) {
+        const children = nodes.slice(open + 1, i);
+        nodes.splice(open, i - open + 1, {
+          type: 'mdxJsxFlowElement',
+          name: 'Callout',
+          attributes,
+          children: hasIntercept ? replaceNodes(children) : children,
+        } as MdastNode);
+        open = -1;
+        hasIntercept = false;
+        attributes.length = 0;
+        i = open;
+      }
+    }
+  }
+
+  return defineMdastPlugin({
+    name: 'remark-admonition',
+    paragraph(node, ctx) {
+      const parent = ctx.parent(node);
+      if (!parent || !('children' in parent)) return;
+      replaceNodes(parent.children as MdastNode[]);
+      ctx.setProperty(parent, 'children', parent.children);
+    },
+    blockquote(node, ctx) {
+      const parent = ctx.parent(node);
+      if (!parent || !('children' in parent)) return;
+      replaceNodes(parent.children as MdastNode[]);
+      ctx.setProperty(parent, 'children', parent.children);
+    },
+    list(node, ctx) {
+      const parent = ctx.parent(node);
+      if (!parent || !('children' in parent)) return;
+      replaceNodes(parent.children as MdastNode[]);
+      ctx.setProperty(parent, 'children', parent.children);
+    },
+  });
+}

--- a/packages/satteri/src/remark-block-id.ts
+++ b/packages/satteri/src/remark-block-id.ts
@@ -1,0 +1,63 @@
+import { defineMdastPlugin } from 'satteri';
+import { flattenNode } from '@/utils';
+import Slugger from 'github-slugger';
+import { createHash } from 'node:crypto';
+import type { MdastNode, MdastVisitorContext } from 'satteri';
+
+export interface RemarkBlockIdOptions {
+  generateId?: (ctx: { node: MdastNode; text: string }) => string;
+  shouldGenerate?: (node: MdastNode) => boolean | 'skip';
+  addDataAttribute?: string | null;
+}
+
+export function remarkBlockId({
+  generateId,
+  addDataAttribute = 'default',
+  shouldGenerate = (node) => {
+    switch (node.type) {
+      case 'mdxJsxFlowElement':
+        return 'skip';
+      case 'paragraph':
+      case 'image':
+      case 'listItem':
+        return true;
+      default:
+        return false;
+    }
+  },
+}: RemarkBlockIdOptions = {}) {
+  return () => {
+    const slugger = new Slugger();
+
+    function visit(node: MdastNode, ctx: MdastVisitorContext) {
+      const data = (node.data ?? {}) as {
+        hProperties?: Record<string, unknown>;
+      };
+      if (data.hProperties?.id) return;
+
+      const resolved = shouldGenerate(node);
+      if (resolved === false || resolved === 'skip') return;
+
+      const text = flattenNode(node).trim();
+      if (text.length === 0) return;
+
+      const id = generateId
+        ? slugger.slug(generateId({ node, text }))
+        : slugger.slug(createHash('sha256').update(text).digest('base64url'));
+
+      data.hProperties ??= {};
+      data.hProperties.id = id;
+      if (addDataAttribute) {
+        data.hProperties['data-block'] = addDataAttribute;
+      }
+      ctx.setProperty(node, 'data', data);
+    }
+
+    return defineMdastPlugin({
+      name: 'remark-block-id',
+      paragraph: visit,
+      image: visit,
+      listItem: visit,
+    });
+  };
+}

--- a/packages/satteri/src/remark-code-tab.ts
+++ b/packages/satteri/src/remark-code-tab.ts
@@ -1,0 +1,197 @@
+import { defineMdastPlugin, mdxToMdast } from 'satteri';
+import type { BlockContent, Code } from 'mdast';
+import type { MdxJsxFlowElement } from 'mdast-util-mdx';
+import {
+  generateCodeBlockTabs,
+  parseCodeBlockAttributes,
+  type CodeBlockTabsOptions,
+} from 'fumadocs-core/mdx-plugins/codeblock-utils';
+
+type TabType = 'CodeBlockTabs' | 'Tabs';
+
+export interface RemarkCodeTabOptions {
+  Tabs?: TabType;
+  parseMdx?: boolean;
+}
+
+function processTabValue(nodes: Code[]) {
+  const out = new Map<string, Code[]>();
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!;
+    const name = (node.data as { tab?: string } | undefined)?.tab ?? `Tab ${i + 1}`;
+    const list = out.get(name) ?? [];
+    list.push(node);
+    out.set(name, list);
+  }
+  return out;
+}
+
+function mdxToAst(name: string): BlockContent[] {
+  const tree = mdxToMdast(name, { features: { gfm: true } }) as { children: BlockContent[] };
+  return tree.children.flatMap((child) => {
+    if (child.type === 'paragraph') return child.children as BlockContent[];
+    return child as BlockContent;
+  });
+}
+
+function buildTabs(
+  tabs: Map<string, Code[]>,
+  mode: TabType,
+  withMdx: boolean,
+  withParent: boolean,
+): BlockContent[] {
+  if (mode === 'CodeBlockTabs') {
+    const options: CodeBlockTabsOptions = { triggers: [], tabs: [] };
+    let isFirst = true;
+    for (const [value, list] of tabs) {
+      if (isFirst) {
+        options.defaultValue = value;
+        const tagGroup = list[0]?.data as { tabGroup?: string } | undefined;
+        if (tagGroup?.tabGroup) options.persist = { id: tagGroup.tabGroup };
+        isFirst = false;
+      }
+      options.triggers.push({
+        value,
+        children: withMdx ? (mdxToAst(value) as BlockContent[]) : [{ type: 'text', value }],
+      });
+      options.tabs.push({ value, children: list });
+    }
+    const node = generateCodeBlockTabs(options);
+    return (withParent ? [node] : node.children) as BlockContent[];
+  }
+
+  const entries = [...tabs.entries()];
+  if (!withMdx) {
+    const children = entries.map(([name, codes]) => ({
+      type: 'mdxJsxFlowElement',
+      name: 'Tab',
+      attributes: [{ type: 'mdxJsxAttribute', name: 'value', value: name }],
+      children: codes,
+    })) satisfies MdxJsxFlowElement[];
+    return withParent
+      ? [
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'Tabs',
+            attributes: [
+              {
+                type: 'mdxJsxAttribute',
+                name: 'items',
+                value: {
+                  type: 'mdxJsxAttributeValueExpression',
+                  value: entries.map(([name]) => name).join(', '),
+                  data: {
+                    estree: {
+                      type: 'Program',
+                      sourceType: 'module',
+                      body: [
+                        {
+                          type: 'ExpressionStatement',
+                          expression: {
+                            type: 'ArrayExpression',
+                            elements: entries.map(([name]) => ({
+                              type: 'Literal',
+                              value: name,
+                            })),
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+            children,
+          },
+        ]
+      : children;
+  }
+
+  const children: MdxJsxFlowElement[] = [
+    {
+      type: 'mdxJsxFlowElement',
+      name: 'TabsList',
+      attributes: [],
+      children: entries.map(([name]) => ({
+        type: 'mdxJsxFlowElement',
+        name: 'TabsTrigger',
+        attributes: [{ type: 'mdxJsxAttribute', name: 'value', value: name }],
+        children: mdxToAst(name),
+      })),
+    },
+    ...entries.map(
+      ([name, codes]) =>
+        ({
+          type: 'mdxJsxFlowElement',
+          name: 'TabsContent',
+          attributes: [{ type: 'mdxJsxAttribute', name: 'value', value: name }],
+          children: codes,
+        }) satisfies MdxJsxFlowElement,
+    ),
+  ];
+
+  return withParent
+    ? [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'Tabs',
+          attributes: [{ type: 'mdxJsxAttribute', name: 'defaultValue', value: entries[0]![0] }],
+          children,
+        },
+      ]
+    : children;
+}
+
+export function remarkCodeTab({ parseMdx = false, Tabs = 'CodeBlockTabs' }: RemarkCodeTabOptions = {}) {
+  return defineMdastPlugin({
+    name: 'remark-code-tab',
+    code(node, ctx) {
+      if (!node.meta) return;
+      const parent = ctx.parent(node);
+      if (!parent || !('children' in parent)) return;
+
+      const meta = parseCodeBlockAttributes(node.meta, ['tab', 'tab-group']);
+      if (!meta.attributes.tab) return;
+
+      const children = [...parent.children] as Code[];
+      const index = ctx.indexOf(node);
+      if (index === undefined) return;
+
+      let start = index;
+      while (start > 0) {
+        const prev = children[start - 1];
+        if (prev?.type !== 'code' || !prev.meta) break;
+        const prevMeta = parseCodeBlockAttributes(prev.meta, ['tab', 'tab-group']);
+        if (!prevMeta.attributes.tab) break;
+        start--;
+      }
+
+      let end = index + 1;
+      while (end < children.length) {
+        const next = children[end];
+        if (next?.type !== 'code' || !next.meta) break;
+        const nextMeta = parseCodeBlockAttributes(next.meta, ['tab', 'tab-group']);
+        if (!nextMeta.attributes.tab) break;
+        end++;
+      }
+
+      const group = children.slice(start, end);
+      for (const item of group) {
+        const parsed = parseCodeBlockAttributes(item.meta!, ['tab', 'tab-group']);
+        item.meta = parsed.rest;
+        item.data ??= {};
+        (item.data as { tab?: string }).tab = parsed.attributes.tab ?? undefined;
+        if (parsed.attributes['tab-group']) {
+          (item.data as { tabGroup?: string }).tabGroup = parsed.attributes['tab-group'];
+        }
+      }
+
+      const replacement = buildTabs(processTabValue(group), Tabs, parseMdx, true)[0]!;
+      const nextChildren = [...parent.children];
+      nextChildren.splice(start, end - start, replacement);
+      ctx.setProperty(parent, 'children', nextChildren);
+    },
+  });
+}
+
+// ponytail: groups adjacent tabbed code blocks when any code node in the group is visited

--- a/packages/satteri/src/remark-directive-admonition.ts
+++ b/packages/satteri/src/remark-directive-admonition.ts
@@ -1,0 +1,100 @@
+import { defineMdastPlugin, type MdastPluginDefinition } from 'satteri';
+import type { BlockContent, DefinitionContent, PhrasingContent } from 'mdast';
+import { replaceChildAt } from '@/utils';
+
+export interface RemarkDirectiveAdmonitionOptions {
+  tags?: {
+    CalloutContainer?: string;
+    CalloutTitle?: string;
+    CalloutDescription?: string;
+  };
+  types?: Record<string, string>;
+}
+
+export function remarkDirectiveAdmonition(
+  options: RemarkDirectiveAdmonitionOptions = {},
+): MdastPluginDefinition {
+  const {
+    tags: {
+      CalloutContainer = 'CalloutContainer',
+      CalloutTitle = 'CalloutTitle',
+      CalloutDescription = 'CalloutDescription',
+    } = {},
+    types = {
+      note: 'info',
+      tip: 'info',
+      info: 'info',
+      warn: 'warning',
+      warning: 'warning',
+      danger: 'error',
+      success: 'success',
+    },
+  } = options;
+
+  return defineMdastPlugin({
+    name: 'remark-directive-admonition',
+    containerDirective(node, ctx) {
+      if (!(node.name in types)) return;
+
+      const attributes = [
+        {
+          type: 'mdxJsxAttribute' as const,
+          name: 'type',
+          value: types[node.name]!,
+        },
+      ];
+
+      for (const [k, v] of Object.entries(node.attributes ?? {})) {
+        attributes.push({
+          type: 'mdxJsxAttribute',
+          name: k,
+          value: String(v),
+        });
+      }
+
+      const titleNodes: PhrasingContent[] = [];
+      const descriptionNodes: (BlockContent | DefinitionContent)[] = [];
+
+      for (const item of node.children) {
+        if (item.type === 'paragraph' && item.data?.directiveLabel) {
+          titleNodes.push(...item.children);
+        } else {
+          descriptionNodes.push(item);
+        }
+      }
+
+      const children: BlockContent[] = [];
+      if (titleNodes.length > 0) {
+        children.push({
+          type: 'mdxJsxFlowElement',
+          name: CalloutTitle,
+          attributes: [],
+          children: titleNodes as BlockContent[],
+        });
+      }
+      if (descriptionNodes.length > 0) {
+        children.push({
+          type: 'mdxJsxFlowElement',
+          name: CalloutDescription,
+          attributes: [],
+          children: descriptionNodes,
+        });
+      }
+
+      const parent = ctx.parent(node);
+      const index = ctx.indexOf(node);
+      if (!parent || index === undefined) return;
+
+      ctx.setProperty(
+        parent,
+        'children',
+        replaceChildAt(parent.children, index, {
+          type: 'mdxJsxFlowElement',
+          attributes,
+          name: CalloutContainer,
+          children,
+        }),
+      );
+    },
+  });
+}

--- a/packages/satteri/src/remark-feedback-block.ts
+++ b/packages/satteri/src/remark-feedback-block.ts
@@ -1,0 +1,75 @@
+import { defineMdastPlugin } from 'satteri';
+import type { BlockContent } from 'mdast';
+import type { MdastNode, MdastVisitorContext } from 'satteri';
+import { flattenNode, handleTag } from '@/utils';
+import { createHash } from 'node:crypto';
+
+export interface RemarkFeedbackBlockOptions {
+  generateHash?: (ctx: { body: string }) => string;
+  tagName?: string;
+  resolve?: (node: MdastNode) => boolean | 'skip';
+  generateBody?: boolean;
+}
+
+export function remarkFeedbackBlock({
+  generateHash = ({ body }) => createHash('md5').update(body).digest('hex').substring(0, 16),
+  tagName = 'FeedbackBlock',
+  resolve = (node) => {
+    switch (node.type) {
+      case 'mdxJsxFlowElement':
+        return 'skip';
+      case 'paragraph':
+      case 'image':
+      case 'listItem':
+        return true;
+      default:
+        return false;
+    }
+  },
+  generateBody = true,
+}: RemarkFeedbackBlockOptions = {}) {
+  return () => {
+    const counts = new Map<string, number>();
+
+    function visit(node: MdastNode, ctx: MdastVisitorContext) {
+      const parent = ctx.parent(node);
+      const index = ctx.indexOf(node);
+      if (!parent || index === undefined) return;
+
+      const resolved = resolve(node);
+      if (resolved === false || resolved === 'skip') return;
+
+      const text = flattenNode(node).trim();
+      if (text.length === 0) return;
+
+      let id = generateHash({ body: text });
+      const count = counts.get(id) ?? 0;
+      if (count > 0) id = `${id}-${count}`;
+      counts.set(id, count + 1);
+
+      const attributes = [
+        { type: 'mdxJsxAttribute' as const, name: 'id', value: id },
+      ];
+      if (generateBody) {
+        attributes.push({ type: 'mdxJsxAttribute', name: 'body', value: text });
+      }
+
+      const children = [...parent.children];
+      children[index] = {
+        type: 'mdxJsxFlowElement',
+        name: tagName,
+        attributes,
+        data: { _stringify: 'children-only' },
+        children: [node as BlockContent],
+      } as never;
+      ctx.setProperty(parent, 'children', children);
+    }
+
+    return defineMdastPlugin({
+      name: 'remark-feedback-block',
+      paragraph: visit,
+      image: visit,
+      listItem: visit,
+    });
+  };
+}

--- a/packages/satteri/src/remark-heading.ts
+++ b/packages/satteri/src/remark-heading.ts
@@ -1,0 +1,71 @@
+import Slugger from 'github-slugger';
+import { defineMdastPlugin } from 'satteri';
+import type { Heading } from 'mdast';
+import type { TOCItemType } from 'fumadocs-core/toc';
+import { flattenNode } from '@/utils';
+
+const regex = /\s*\[#(?<slug>[^]+?)]\s*$/;
+
+export interface RemarkHeadingOptions {
+  slug?: (heading: Heading, text: string) => string;
+  customId?: boolean;
+  generateToc?: boolean;
+}
+
+declare module 'satteri' {
+  interface DataMap {
+    toc?: TOCItemType[];
+  }
+}
+
+export function remarkHeading({
+  slug,
+  customId = true,
+  generateToc = true,
+}: RemarkHeadingOptions = {}) {
+  return () => {
+    const slugger = slug ? undefined : new Slugger();
+    const resolveSlug = slug ?? ((_heading, text) => slugger!.slug(text));
+
+    let sluggerReady = false;
+
+    return defineMdastPlugin({
+      name: 'remark-heading',
+      heading(node, ctx) {
+        if (!sluggerReady) {
+          slugger?.reset();
+          sluggerReady = true;
+        }
+
+        const data = (node.data ?? {}) as { hProperties?: Record<string, unknown> };
+        const hProperties = (data.hProperties ??= {});
+
+        const lastNode = node.children.at(-1);
+        if (lastNode?.type === 'text' && customId) {
+          const match = regex.exec(lastNode.value);
+          if (match?.[1]) {
+            hProperties.id = match[1];
+            ctx.setProperty(lastNode, 'value', lastNode.value.slice(0, match.index!));
+          }
+        }
+
+        let flattened: string | null = null;
+        if (!hProperties.id) {
+          flattened = flattenNode(node);
+          hProperties.id = resolveSlug(node, flattened);
+        }
+
+        ctx.setProperty(node, 'data', data as typeof node.data);
+
+        if (generateToc) {
+          const toc = (ctx.data.toc ??= []);
+          toc.push({
+            title: flattened ?? flattenNode(node),
+            url: `#${hProperties.id}`,
+            depth: node.depth,
+          });
+        }
+      },
+    });
+  };
+}

--- a/packages/satteri/src/remark-image.ts
+++ b/packages/satteri/src/remark-image.ts
@@ -1,0 +1,214 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineMdastPlugin } from 'satteri';
+import type { Image, RootContent } from 'mdast';
+import type { MdxJsxFlowElement, MdxjsEsm } from 'mdast-util-mdx';
+import { replaceChildAt } from '@/utils';
+
+const VALID_BLUR_EXT = ['.jpeg', '.png', '.webp', '.avif', '.jpg'];
+const EXTERNAL_URL_REGEX = /^https?:\/\//;
+
+type ExternalImageOptions = { timeout?: number } | boolean;
+
+export interface RemarkImageOptions {
+  publicDir?: string;
+  placeholder?: 'blur' | 'none';
+  onError?: 'error' | 'hide' | 'ignore' | ((error: Error) => void);
+  useImport?: boolean;
+  external?: ExternalImageOptions;
+}
+
+type Source = { type: 'url'; url: URL } | { type: 'file'; file: string };
+
+declare module 'satteri' {
+  interface DataMap {
+    _imageImports?: MdxjsEsm[];
+  }
+}
+
+export function remarkImage({
+  placeholder = 'none',
+  external = true,
+  useImport = true,
+  onError = 'error',
+  publicDir = path.join(process.cwd(), 'public'),
+}: RemarkImageOptions = {}) {
+  return () => {
+    const imports: MdxjsEsm[] = [];
+
+    return defineMdastPlugin({
+      name: 'remark-image',
+      async image(node, ctx) {
+        const parent = ctx.parent(node);
+        const index = ctx.indexOf(node);
+        if (!parent || index === undefined) return;
+
+        const dir = ctx.fileURL ? path.dirname(fileURLToPath(ctx.fileURL)) : undefined;
+        const src = parseSrc(decodeURI(node.url), publicDir, dir);
+        if (!src) return;
+
+        try {
+          const replacement = await updateImage(src, node, {
+            placeholder,
+            useImport,
+            external,
+            dir,
+            imports,
+          });
+          if (replacement) {
+            ctx.setProperty(parent, 'children', replaceChildAt(parent.children, index, replacement));
+          }
+        } catch (error) {
+          if (onError === 'hide') {
+            ctx.removeNode(node);
+          } else if (onError === 'ignore' || node.url.endsWith('.svg')) {
+            return;
+          } else if (typeof onError === 'function') {
+            onError(error as Error);
+          } else {
+            throw error;
+          }
+        }
+
+        if (imports.length > 0) {
+          ctx.data._imageImports = imports;
+        }
+      },
+    });
+  };
+}
+
+async function updateImage(
+  src: Source,
+  node: Image,
+  ctx: {
+    placeholder: 'blur' | 'none';
+    useImport: boolean;
+    external: ExternalImageOptions;
+    dir?: string;
+    imports: MdxjsEsm[];
+  },
+): Promise<RootContent | undefined> {
+  if (src.type === 'file' && ctx.useImport) {
+    if (!ctx.dir) {
+      throw new Error(
+        'When `useImport` is enabled, pass `fileURL` to the compiler so image paths can be resolved.',
+      );
+    }
+
+    const variableName = `__img${ctx.imports.length}`;
+    const importPath = getImportPath(src.file, ctx.dir);
+    ctx.imports.push({
+      type: 'mdxjsEsm',
+      value: '',
+      data: {
+        estree: {
+          type: 'Program',
+          sourceType: 'module',
+          body: [
+            {
+              type: 'ImportDeclaration',
+              attributes: [],
+              source: { type: 'Literal', value: importPath },
+              specifiers: [
+                {
+                  type: 'ImportDefaultSpecifier',
+                  local: { type: 'Identifier', name: variableName },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    const out: MdxJsxFlowElement = {
+      type: 'mdxJsxFlowElement',
+      name: 'img',
+      children: [],
+      attributes: [
+        { type: 'mdxJsxAttribute', name: 'alt', value: node.alt ?? 'image' },
+        {
+          type: 'mdxJsxAttribute',
+          name: 'src',
+          value: {
+            type: 'mdxJsxAttributeValueExpression',
+            value: variableName,
+            data: {
+              estree: {
+                type: 'Program',
+                sourceType: 'module',
+                body: [
+                  {
+                    type: 'ExpressionStatement',
+                    expression: { type: 'Identifier', name: variableName },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    if (ctx.placeholder === 'blur' && VALID_BLUR_EXT.some((ext) => src.file.endsWith(ext))) {
+      out.attributes.push({ type: 'mdxJsxAttribute', name: 'placeholder', value: 'blur' });
+    }
+
+    return out;
+  }
+
+  const size = await getImageSize(src, ctx.external);
+  if (!size) return;
+
+  node.data ??= {};
+  const props = ((node.data as { hProperties?: Record<string, string> }).hProperties ??= {});
+  props.src = src.type === 'url' ? src.url.href : node.url;
+  props.width = size.width.toString();
+  props.height = size.height.toString();
+  return node;
+}
+
+function getImportPath(file: string, dir: string): string {
+  const relative = path.relative(dir, file).replaceAll(path.sep, '/');
+  return relative.startsWith('../') ? relative : `./${relative}`;
+}
+
+function parseSrc(src: string, publicDir: string, dir?: string): Source | undefined {
+  if (src.startsWith('file:///')) return { type: 'file', file: fileURLToPath(src) };
+  if (EXTERNAL_URL_REGEX.test(src)) return { type: 'url', url: new URL(src) };
+
+  if (src.startsWith('/')) {
+    if (EXTERNAL_URL_REGEX.test(publicDir)) {
+      const url = new URL(publicDir);
+      const segs = [...url.pathname.split('/'), ...src.split('/')].filter((v) => v.length > 0);
+      url.pathname = `/${segs.join('/')}`;
+      return { type: 'url', url };
+    }
+    return { type: 'file', file: path.join(publicDir, src) };
+  }
+
+  if (!dir) return;
+  return { type: 'file', file: path.join(dir, src) };
+}
+
+async function getImageSize(src: Source, onExternal: ExternalImageOptions) {
+  if (src.type === 'file') {
+    const { imageSizeFromFile } = await import('image-size/fromFile');
+    return imageSizeFromFile(src.file);
+  }
+  if (onExternal === false) return;
+
+  const { timeout } = typeof onExternal === 'object' ? onExternal : {};
+  const res = await fetch(src.url, {
+    signal: typeof timeout === 'number' ? AbortSignal.timeout(timeout) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(`[Remark Image] Failed to fetch ${src.url} (${res.status})`);
+  }
+
+  const { imageSize } = await import('image-size');
+  return imageSize(new Uint8Array(await res.arrayBuffer()));
+}
+
+export { parseSrc, getImageSize };

--- a/packages/satteri/src/remark-mdx-mermaid.ts
+++ b/packages/satteri/src/remark-mdx-mermaid.ts
@@ -1,0 +1,36 @@
+import { defineMdastPlugin } from 'satteri';
+import { replaceChildAt } from '@/utils';
+
+export interface RemarkMdxMermaidOptions {
+  lang?: string;
+}
+
+export function remarkMdxMermaid({ lang = 'mermaid' }: RemarkMdxMermaidOptions = {}) {
+  return defineMdastPlugin({
+    name: 'remark-mdx-mermaid',
+    code(node, ctx) {
+      if (node.lang !== lang || !node.value) return;
+
+      const parent = ctx.parent(node);
+      const index = ctx.indexOf(node);
+      if (!parent || index === undefined) return;
+
+      ctx.setProperty(
+        parent,
+        'children',
+        replaceChildAt(parent.children, index, {
+          type: 'mdxJsxFlowElement',
+          name: 'Mermaid',
+          attributes: [
+            {
+              type: 'mdxJsxAttribute',
+              name: 'chart',
+              value: node.value.trim(),
+            },
+          ],
+          children: [],
+        }),
+      );
+    },
+  });
+}

--- a/packages/satteri/src/remark-npm.ts
+++ b/packages/satteri/src/remark-npm.ts
@@ -1,0 +1,92 @@
+import { defineMdastPlugin } from 'satteri';
+import convert from 'npm-to-yarn';
+import { generateCodeBlockTabs } from 'fumadocs-core/mdx-plugins/codeblock-utils';
+import type { CodeBlockTabsOptions } from 'fumadocs-core/mdx-plugins/codeblock-utils';
+import { replaceChildAt } from '@/utils';
+
+interface PackageManager {
+  name: string;
+  value?: string;
+  command: (command: string) => string | undefined;
+}
+
+export interface RemarkNpmOptions {
+  persist?: { id: string } | false;
+  packageManagers?: PackageManager[];
+}
+
+function convertLines(cmd: string, to: 'yarn' | 'pnpm' | 'bun') {
+  return cmd
+    .split('\n')
+    .map((l) => convert(l, to))
+    .join('\n');
+}
+
+export function remarkNpm({
+  persist = false,
+  packageManagers = [
+    { command: (cmd) => cmd, name: 'npm' },
+    { command: (cmd) => convertLines(cmd, 'pnpm'), name: 'pnpm' },
+    { command: (cmd) => convertLines(cmd, 'yarn'), name: 'yarn' },
+    { command: (cmd) => convertLines(cmd, 'bun'), name: 'bun' },
+  ],
+}: RemarkNpmOptions = {}) {
+  return defineMdastPlugin({
+    name: 'remark-npm',
+    code(node, ctx) {
+      const parent = ctx.parent(node);
+      const index = ctx.indexOf(node);
+      if (!parent || index === undefined) return;
+
+      let code: string;
+      switch (node.lang) {
+        case 'package-install':
+          code = node.value;
+          if (!code.startsWith('npm') && !code.startsWith('npx')) {
+            code = `npm install ${code}`;
+          }
+          break;
+        case 'npm':
+          code = node.value;
+          break;
+        default:
+          return;
+      }
+
+      const options: CodeBlockTabsOptions = {
+        persist,
+        tabs: [],
+        triggers: [],
+      };
+
+      for (const manager of packageManagers) {
+        const value = manager.value ?? manager.name;
+        const command = manager.command(code);
+        if (!command || command.length === 0) continue;
+
+        options.defaultValue ??= value;
+        options.triggers.push({
+          value,
+          children: [{ type: 'text', value: manager.name }],
+        });
+        options.tabs.push({
+          value,
+          children: [
+            {
+              type: 'code',
+              lang: 'bash',
+              meta: node.meta,
+              value: command,
+            },
+          ],
+        });
+      }
+
+      ctx.setProperty(
+        parent,
+        'children',
+        replaceChildAt(parent.children, index, generateCodeBlockTabs(options)),
+      );
+    },
+  });
+}

--- a/packages/satteri/src/remark-steps.ts
+++ b/packages/satteri/src/remark-steps.ts
@@ -1,0 +1,121 @@
+import { defineMdastPlugin } from 'satteri';
+import type { Heading } from 'mdast';
+import type { MdastNode, MdastVisitorContext } from 'satteri';
+import { handleTag } from '@/utils';
+
+export interface RemarkStepsOptions {
+  steps?: string;
+  step?: string;
+}
+
+const StepRegex = /^(\d+)\.\s(.+)$/;
+const StepTag = '[step]';
+
+export function remarkSteps({ steps = 'fd-steps', step = 'fd-step' }: RemarkStepsOptions = {}) {
+  function convertToSteps(nodes: MdastNode[]) {
+    const depth = (nodes[0] as Heading).depth;
+    const children: MdastNode[] = [];
+
+    for (const node of nodes) {
+      if (node.type === 'heading' && node.depth === depth) {
+        children.push({
+          type: 'mdxJsxFlowElement',
+          name: 'div',
+          attributes: [{ type: 'mdxJsxAttribute', name: 'className', value: step }],
+          children: [node],
+        });
+      } else {
+        (children[children.length - 1] as { children: MdastNode[] }).children.push(node);
+      }
+    }
+
+    return {
+      type: 'mdxJsxFlowElement',
+      name: 'div',
+      attributes: [{ type: 'mdxJsxAttribute', name: 'className', value: steps }],
+      children,
+    } as MdastNode;
+  }
+
+  function handleHeadingStep(node: Heading): boolean {
+    const head = node.children[0];
+    if (head?.type === 'text') {
+      const match = StepRegex.exec(head.value);
+      if (match) {
+        head.value = match[2]!;
+        return true;
+      }
+    }
+
+    const tail = node.children[node.children.length - 1];
+    if (tail?.type === 'text') {
+      const stepValue = handleTag(tail.value, StepTag);
+      if (stepValue !== false) {
+        tail.value = stepValue;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function processChildren(
+    children: MdastNode[],
+    ctx: MdastVisitorContext,
+    parent: MdastNode,
+  ) {
+    let startIdx = -1;
+    let i = 0;
+    let currentStep = 1;
+
+    const onEnd = () => {
+      if (startIdx === -1) return;
+      const nodes = children.splice(startIdx, i - startIdx);
+      children.splice(startIdx, 0, convertToSteps(nodes));
+      i = startIdx + 1;
+      startIdx = -1;
+      currentStep = 1;
+    };
+
+    for (; i < children.length; i++) {
+      const node = children[i]!;
+      if (node.type !== 'heading') continue;
+
+      const data = (node.data ?? {}) as { hProperties?: Record<string, unknown> };
+      if (data.hProperties?.['data-fd-step'] !== undefined) continue;
+
+      if (startIdx !== -1) {
+        const startDepth = (children[startIdx] as Heading).depth;
+        if (node.depth !== startDepth) {
+          if (node.depth < startDepth) onEnd();
+          continue;
+        }
+      }
+
+      if (!handleHeadingStep(node)) {
+        onEnd();
+        continue;
+      }
+
+      data.hProperties ??= {};
+      data.hProperties['data-fd-step'] = currentStep++;
+      ctx.setProperty(node, 'data', data);
+      if (startIdx === -1) startIdx = i;
+    }
+
+    onEnd();
+    ctx.setProperty(parent, 'children', children);
+  }
+
+  function visitContainer(node: MdastNode, ctx: MdastVisitorContext) {
+    if (!('children' in node)) return;
+    processChildren([...node.children] as MdastNode[], ctx, node);
+  }
+
+  return defineMdastPlugin({
+    name: 'remark-steps',
+    blockquote: visitContainer,
+    list: visitContainer,
+    mdxJsxFlowElement: visitContainer,
+  });
+}

--- a/packages/satteri/src/remark-structure.ts
+++ b/packages/satteri/src/remark-structure.ts
@@ -1,0 +1,107 @@
+import { defineMdastPlugin } from 'satteri';
+import type { Nodes } from 'mdast';
+import type { StructuredData } from 'fumadocs-core/mdx-plugins/remark-structure';
+import { flattenNode } from '@/utils';
+import { queueDataExport } from '@/inject-exports';
+
+export interface StructureOptions {
+  types?: string[] | ((node: Nodes) => boolean);
+  mdxTypes?: (node: Nodes) => boolean;
+  exportAs?: string | boolean;
+}
+
+declare module 'satteri' {
+  interface DataMap {
+    structuredData?: StructuredData;
+    frontmatter?: Record<string, unknown>;
+  }
+}
+
+export function remarkStructure({
+  types = ['heading', 'paragraph', 'blockquote', 'tableCell', 'mdxJsxFlowElement'],
+  mdxTypes = (node) => !('children' in node) || node.children.length === 0,
+  exportAs = false,
+}: StructureOptions = {}) {
+  const matchType =
+    typeof types === 'function' ? types : (node: Nodes) => types.includes(node.type);
+
+    return () => {
+    const data: StructuredData = { contents: [], headings: [] };
+    let lastHeading: string | undefined;
+    let seeded = false;
+    let exported = false;
+
+    function finish(ctx: { data: Record<string, unknown> }) {
+      ctx.data.structuredData = data;
+      if (exportAs && !exported) {
+        exported = true;
+        queueDataExport(
+          ctx.data,
+          typeof exportAs === 'string' ? exportAs : 'structuredData',
+          data,
+        );
+      }
+    }
+
+    function visit(node: Nodes, ctx: { data: Record<string, unknown> }) {
+      if (!matchType(node)) return;
+      if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+        if (!mdxTypes(node)) return;
+      }
+
+      if (!seeded) {
+        const frontmatter = ctx.data.frontmatter as
+          | { _openapi?: { structuredData?: StructuredData } }
+          | undefined;
+        const openapiData = frontmatter?._openapi?.structuredData;
+        if (openapiData) {
+          data.headings.push(...openapiData.headings);
+          data.contents.push(...openapiData.contents);
+        }
+        seeded = true;
+      }
+
+      if (node.type === 'heading') {
+        const headingData = (node.data ?? {}) as { hProperties?: { id?: string } };
+        const id = headingData.hProperties?.id;
+        if (!id) return;
+
+        const content = flattenNode(node).trim();
+        if (content.length > 0) data.headings.push({ id, content });
+        lastHeading = id;
+        return;
+      }
+
+      const content = flattenNode(node).trim();
+      if (content.length > 0) {
+        data.contents.push({ heading: lastHeading, content });
+      }
+    }
+
+    return defineMdastPlugin({
+      name: 'remark-structure',
+      heading(node, ctx) {
+        visit(node, ctx);
+        finish(ctx);
+      },
+      paragraph(node, ctx) {
+        visit(node, ctx);
+        finish(ctx);
+      },
+      blockquote(node, ctx) {
+        visit(node, ctx);
+        finish(ctx);
+      },
+      tableCell(node, ctx) {
+        visit(node, ctx);
+        finish(ctx);
+      },
+      mdxJsxFlowElement(node, ctx) {
+        visit(node, ctx);
+        finish(ctx);
+      },
+    });
+  };
+}
+
+export type { StructuredData } from 'fumadocs-core/mdx-plugins/remark-structure';

--- a/packages/satteri/src/types.ts
+++ b/packages/satteri/src/types.ts
@@ -1,0 +1,1 @@
+export type BuildEnvironment = 'bundler' | 'runtime';

--- a/packages/satteri/src/utils.ts
+++ b/packages/satteri/src/utils.ts
@@ -1,0 +1,30 @@
+import type { MdastNode } from 'satteri';
+
+export function flattenNode(node: MdastNode): string {
+  if ('children' in node && Array.isArray(node.children)) {
+    return node.children.map((child) => flattenNode(child)).join('');
+  }
+
+  if ('value' in node && typeof node.value === 'string') return node.value;
+
+  return '';
+}
+
+export function handleTag(value: string, tag: string): string | false {
+  const idx = value.indexOf(tag);
+  if (idx !== -1) {
+    return value.slice(0, idx).trimEnd() + value.slice(idx + tag.length);
+  }
+
+  return false;
+}
+
+export function replaceChildAt(
+  children: readonly MdastNode[],
+  index: number,
+  node: MdastNode,
+): MdastNode[] {
+  const next = [...children];
+  next[index] = node;
+  return next;
+}

--- a/packages/satteri/test/preset.test.ts
+++ b/packages/satteri/test/preset.test.ts
@@ -13,6 +13,6 @@ describe('@fumadocs/satteri', () => {
 
     expect(code).toContain('export default');
     expect(code).toContain('export const frontmatter');
-    expect(data.structuredData).toBeDefined();
+    expect(data?.structuredData).toBeDefined();
   });
 });

--- a/packages/satteri/test/preset.test.ts
+++ b/packages/satteri/test/preset.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { applySatteriPreset, compileMdx } from '@fumadocs/satteri';
+
+describe('@fumadocs/satteri', () => {
+  it('compiles mdx with fumadocs preset', async () => {
+    const options = await applySatteriPreset({ rehypeCodeOptions: false })('bundler');
+    const { code, data } = await compileMdx({
+      source: '# Hello\n\nWorld',
+      filePath: '/tmp/test.mdx',
+      frontmatter: { title: 'Test' },
+      options,
+    });
+
+    expect(code).toContain('export default');
+    expect(code).toContain('export const frontmatter');
+    expect(data.structuredData).toBeDefined();
+  });
+});

--- a/packages/satteri/test/rehype-code.test.ts
+++ b/packages/satteri/test/rehype-code.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins/rehype-code';
+import { compileMdx, applySatteriPreset } from '@fumadocs/satteri';
+
+describe('rehype-code', () => {
+  it('highlights fenced code blocks', async () => {
+    const options = await applySatteriPreset({
+      rehypeCodeOptions: {
+        ...rehypeCodeDefaultOptions,
+        lazy: false,
+        langs: ['js'],
+      },
+    })('bundler');
+
+    const { code } = await compileMdx({
+      source: '```js\nconst x = 1\n```',
+      filePath: '/tmp/test.mdx',
+      options,
+    });
+
+    expect(code).toContain('shiki');
+    expect(code).toContain('const');
+  });
+});

--- a/packages/satteri/tsconfig.json
+++ b/packages/satteri/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "fumadocs-core/*": ["../core/dist/*"]
+    },
+    "types": ["@types/node", "@types/mdast", "@types/hast"],
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "target": "ES2023"
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/satteri/tsdown.config.ts
+++ b/packages/satteri/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  dts: {
+    sourcemap: false,
+  },
+  fixedExtension: false,
+  target: 'es2023',
+  format: 'esm',
+  entry: ['src/index.ts', 'src/preset.ts', 'src/compile.ts'],
+  deps: {
+    onlyBundle: [],
+    neverBundle: ['fumadocs-core', 'satteri', 'unified', 'vfile', 'mdast-util-mdx', /^@types\//],
+  },
+});

--- a/packages/satteri/vitest.config.ts
+++ b/packages/satteri/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2724,6 +2724,9 @@ importers:
 
   packages/mdx:
     dependencies:
+      '@fumadocs/satteri':
+        specifier: workspace:*
+        version: link:../satteri
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1
@@ -2818,6 +2821,9 @@ importers:
       rolldown:
         specifier: ^1.1.2
         version: 1.1.2
+      satteri:
+        specifier: ^0.9.4
+        version: 0.9.4
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -3407,6 +3413,73 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  packages/satteri:
+    dependencies:
+      estree-util-to-js:
+        specifier: ^2.0.0
+        version: 2.0.0
+      estree-util-value-to-estree:
+        specifier: ^3.5.0
+        version: 3.5.0
+      fumadocs-core:
+        specifier: workspace:*
+        version: link:../core
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
+      hast-util-to-estree:
+        specifier: ^3.1.3
+        version: 3.1.3
+      image-size:
+        specifier: ^2.0.2
+        version: 2.0.2
+      npm-to-yarn:
+        specifier: ^3.0.1
+        version: 3.0.1
+      satteri:
+        specifier: ^0.9.4
+        version: 0.9.4
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+    devDependencies:
+      '@types/estree':
+        specifier: ^1.0.9
+        version: 1.0.9
+      '@types/estree-jsx':
+        specifier: ^1.0.5
+        version: 1.0.5
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@types/node':
+        specifier: 26.0.0
+        version: 26.0.0
+      mdast-util-mdx:
+        specifier: ^3.0.0
+        version: 3.0.0
+      shiki:
+        specifier: ^3.0.0
+        version: 3.23.0
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+      tsdown:
+        specifier: 0.22.3
+        version: 0.22.3(@tsdown/css@0.22.3)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(tsx@4.22.4)(typescript@6.0.3)(unrun@0.3.1)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/shadcn:
     dependencies:
@@ -4757,52 +4830,52 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@bruits/satteri-darwin-arm64@0.9.2':
-    resolution: {integrity: sha512-tRpKRsiWxyh+Q5cjLwqj+baqI9htIcKqpDcftygA08bB/4nocZsneq+CVLmqT1/njG2Gq+ET12JHECz52ybiPQ==}
+  '@bruits/satteri-darwin-arm64@0.9.4':
+    resolution: {integrity: sha512-W3MSUkr2mZRR8Stoe+lqNAyzQzRuFMU8WffV9IvFSxTok0LGWR0ZZQPLELU4QTRiUbhL2Y4VUP9vV7pj8rHjgg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@bruits/satteri-darwin-x64@0.9.2':
-    resolution: {integrity: sha512-oLSI0+Upq3Nd1brOdRSl044TMKgy7S6cF4sM7a9/Ms6/IADvuey+9yG3GBXxLGAzSYzR0/hh7PPSP1QBfsBKwA==}
+  '@bruits/satteri-darwin-x64@0.9.4':
+    resolution: {integrity: sha512-DXOuuaE1lsv7mpk2mOvGrzqoEWEvOIZEO/fXVa7zfM23Iob+CBjBkRAMwpHA4pmZ3j6Gj7WJzPKw0kQ7w741AQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@bruits/satteri-linux-arm64-gnu@0.9.2':
-    resolution: {integrity: sha512-G+G6uYscRc4VUTNgZgS6SSfTHh04q/d5WiH66Jg39eftMzTAsT5cLSEHDTvDpleUT6BMNHdunx927WbddDgw7A==}
+  '@bruits/satteri-linux-arm64-gnu@0.9.4':
+    resolution: {integrity: sha512-gJxU9rGGoqIznSEgEzpjxkry24jeHuMpoo1tCIAhHYh7WaD3j5F8zt3jmHxEaN1Uwa+K5+wFgIR2uIGOnMzEmw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@bruits/satteri-linux-arm64-musl@0.9.2':
-    resolution: {integrity: sha512-wRaKSHCRXwzAZwlieCiv3u8pWEE2t9FmhZ0X59YZvHCGin56YUBOTyEQqSOrRfXs6fhUb8ylprisGYJC6J8mFQ==}
+  '@bruits/satteri-linux-arm64-musl@0.9.4':
+    resolution: {integrity: sha512-Wjzu9hmmAbfmDkBfPI1VdZygJtYz9uYZQnkEyrXi6S2JFi+2pXQ1A5irj38bqm0IZmWcTbk0cVG4NZnPdtVNJA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@bruits/satteri-linux-x64-gnu@0.9.2':
-    resolution: {integrity: sha512-hxEq3g/kS3tm3GKc2aRYnLMFI5IjxYzcd2sCwEH2C0V+m9TTAf+7Snt/+AZZklpxDOBrI+zthJHip9xnk9uM3g==}
+  '@bruits/satteri-linux-x64-gnu@0.9.4':
+    resolution: {integrity: sha512-MR1Q+wMx65FQlbSV7cRqWW87Knp0zkoaIV55Dt+xZl028wJABXEPEEmG3670SLq7lVZvcGIDwCgSg2kCYxvRwA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@bruits/satteri-linux-x64-musl@0.9.2':
-    resolution: {integrity: sha512-ZSu+a07Efn8sOeA1k9ZM9CO9J3sAeG37Sf2YYxi/unFGgkFe+Y8MHDQlUNtngpC8pkYIjkojkLFT6v1yiHNxOg==}
+  '@bruits/satteri-linux-x64-musl@0.9.4':
+    resolution: {integrity: sha512-T4gxhXve3zyNAZesrXAd/rDZOGRkbfFIUFld4TGsw6BsjoIteCcDji6IMqeXyaWEVSykY2X8Eid2hr6aXGYAaw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@bruits/satteri-wasm32-wasi@0.9.2':
-    resolution: {integrity: sha512-Q/d7OIwXb5UGaiKUuPp2E6Bm41xD3sW8ts5L6l2m0Wi9uu9WKsv7CDc1ge6AVd6OC6g4nlSKWECFfPa7MkJchg==}
+  '@bruits/satteri-wasm32-wasi@0.9.4':
+    resolution: {integrity: sha512-/CEG8LUlpaBEnhFnYVn0UnlHFLs51UhrkJBUPDUXLzkadzAcnR88iRA/nOl7Zwhjb4WhfBV4p3P5qeOJMtH0iA==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@bruits/satteri-win32-arm64-msvc@0.9.2':
-    resolution: {integrity: sha512-QeaVjw+2IZeDRU7dU0KFlECTAwbL4fRUIXxZYQc4a16ejPzwizChEsKzoUBduyOJSDjyzvZxAmcdUYsSOUmR9A==}
+  '@bruits/satteri-win32-arm64-msvc@0.9.4':
+    resolution: {integrity: sha512-E1ZPQbgCtFKiU7pFYVndynvY7ne4coeVDUgnVThErSFlJ2ceQCBZrfRTD1lzrIDy63Bbqo+g/cZY9duw+JYjIw==}
     cpu: [arm64]
     os: [win32]
 
-  '@bruits/satteri-win32-x64-msvc@0.9.2':
-    resolution: {integrity: sha512-+hVrOLFtGgXakKO38F6afcc9/uuWvRGghPmiA6/ez5XGnWaM9VjQxqvogam5aOa7Nvl4V65P8Vpj5RsLzYeO8g==}
+  '@bruits/satteri-win32-x64-msvc@0.9.4':
+    resolution: {integrity: sha512-5I7SiarsNdAUuhJb50CXJPTwr/ECVrBoU+fymoLjChK5fW//+srhY4lstcNTzgFRtQSYfVtm4OQZz16CVMeTeA==}
     cpu: [x64]
     os: [win32]
 
@@ -6390,6 +6463,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -8699,12 +8778,18 @@ packages:
   '@shikijs/core@1.17.7':
     resolution: {integrity: sha512-ZnIDxFu/yvje3Q8owSHaEHd+bu/jdWhHAaJ17ggjXofHx5rc4bhpCSW+OjC6smUBi5s5dd023jWtZ1gzMu/yrw==}
 
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
   '@shikijs/core@4.2.0':
     resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
     engines: {node: '>=20'}
 
   '@shikijs/engine-javascript@1.17.7':
     resolution: {integrity: sha512-wwSf7lKPsm+hiYQdX+1WfOXujtnUG6fnN4rCmExxa4vo+OTmvZ9B1eKauilvol/LHUPrQgW12G3gzem7pY5ckw==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
   '@shikijs/engine-javascript@4.2.0':
     resolution: {integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==}
@@ -8713,9 +8798,15 @@ packages:
   '@shikijs/engine-oniguruma@1.17.7':
     resolution: {integrity: sha512-pvSYGnVeEIconU28NEzBXqSQC/GILbuNbAHwMoSfdTBrobKAsV1vq2K4cAgiaW1TJceLV9QMGGh18hi7cCzbVQ==}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
   '@shikijs/engine-oniguruma@4.2.0':
     resolution: {integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==}
     engines: {node: '>=20'}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/langs@4.2.0':
     resolution: {integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==}
@@ -8724,6 +8815,9 @@ packages:
   '@shikijs/primitive@4.2.0':
     resolution: {integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==}
     engines: {node: '>=20'}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
 
   '@shikijs/themes@4.2.0':
     resolution: {integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==}
@@ -8744,6 +8838,9 @@ packages:
 
   '@shikijs/types@1.17.7':
     resolution: {integrity: sha512-+qA4UyhWLH2q4EFd+0z4K7GpERDU+c+CN2XYD3sC+zjvAr5iuwD1nToXZMt1YODshjkEGEDV86G7j66bKjqDdg==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.2.0':
     resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
@@ -14115,8 +14212,8 @@ packages:
       react-dom: ^19.2.2
       styled-components: ^6.1.15
 
-  satteri@0.9.2:
-    resolution: {integrity: sha512-IDJTE5SzEg9PqtdZEToQ3bjlfQ/zM+/HNaBFrwPdZbtk9IL1RWVFvzR8EMIrC0JYybJNKZS8FL45GNSAMX/6Xg==}
+  satteri@0.9.4:
+    resolution: {integrity: sha512-BKob126Tay84diOZsnVNH/Q/c+3njPJTCad3w5zLKa6j8bVjxskPNHDtxrMwYK4bN/RlqUSdMnPwKY4k65EMOQ==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -14246,6 +14343,9 @@ packages:
 
   shiki@1.17.7:
     resolution: {integrity: sha512-Zf6hNtWhFyF4XP5OOsXkBTEx9JFPiN0TQx4wSe+Vqeuczewgk2vT4IZhF4gka55uelm052BD5BaHavNqUNZd+A==}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   shiki@4.2.0:
     resolution: {integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==}
@@ -15971,7 +16071,7 @@ snapshots:
 
   '@astrojs/compiler-binding-wasm32-wasi@0.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -16043,7 +16143,7 @@ snapshots:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/prism': 4.0.2
       github-slugger: 2.0.0
-      satteri: 0.9.2
+      satteri: 0.9.4
 
   '@astrojs/mdx@7.0.0(@astrojs/markdown-satteri@0.3.2)(astro@7.0.2(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(db0@0.3.4)(jiti@2.7.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -16981,35 +17081,35 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@bruits/satteri-darwin-arm64@0.9.2':
+  '@bruits/satteri-darwin-arm64@0.9.4':
     optional: true
 
-  '@bruits/satteri-darwin-x64@0.9.2':
+  '@bruits/satteri-darwin-x64@0.9.4':
     optional: true
 
-  '@bruits/satteri-linux-arm64-gnu@0.9.2':
+  '@bruits/satteri-linux-arm64-gnu@0.9.4':
     optional: true
 
-  '@bruits/satteri-linux-arm64-musl@0.9.2':
+  '@bruits/satteri-linux-arm64-musl@0.9.4':
     optional: true
 
-  '@bruits/satteri-linux-x64-gnu@0.9.2':
+  '@bruits/satteri-linux-x64-gnu@0.9.4':
     optional: true
 
-  '@bruits/satteri-linux-x64-musl@0.9.2':
+  '@bruits/satteri-linux-x64-musl@0.9.4':
     optional: true
 
-  '@bruits/satteri-wasm32-wasi@0.9.2':
+  '@bruits/satteri-wasm32-wasi@0.9.4':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@bruits/satteri-win32-arm64-msvc@0.9.2':
+  '@bruits/satteri-win32-arm64-msvc@0.9.4':
     optional: true
 
-  '@bruits/satteri-win32-x64-msvc@0.9.2':
+  '@bruits/satteri-win32-x64-msvc@0.9.4':
     optional: true
 
   '@capsizecss/unpack@4.0.1':
@@ -18359,13 +18459,6 @@ snapshots:
       hls.js: 1.6.16
       mux-embed: 5.18.1
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
       '@emnapi/core': 1.11.0
@@ -18374,6 +18467,20 @@ snapshots:
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
@@ -18720,7 +18827,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.128.0':
@@ -18786,7 +18893,7 @@ snapshots:
 
   '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -20820,6 +20927,13 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/core@4.2.0':
     dependencies:
       '@shikijs/primitive': 4.2.0
@@ -20834,6 +20948,12 @@ snapshots:
       '@shikijs/vscode-textmate': 9.3.1
       oniguruma-to-js: 0.4.3
 
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
   '@shikijs/engine-javascript@4.2.0':
     dependencies:
       '@shikijs/types': 4.2.0
@@ -20845,10 +20965,19 @@ snapshots:
       '@shikijs/types': 1.17.7
       '@shikijs/vscode-textmate': 9.3.1
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/engine-oniguruma@4.2.0':
     dependencies:
       '@shikijs/types': 4.2.0
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
   '@shikijs/langs@4.2.0':
     dependencies:
@@ -20859,6 +20988,10 @@ snapshots:
       '@shikijs/types': 4.2.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
   '@shikijs/themes@4.2.0':
     dependencies:
@@ -20885,6 +21018,11 @@ snapshots:
   '@shikijs/types@1.17.7':
     dependencies:
       '@shikijs/vscode-textmate': 9.3.1
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
   '@shikijs/types@4.2.0':
@@ -27470,22 +27608,22 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  satteri@0.9.2:
+  satteri@0.9.4:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
     optionalDependencies:
-      '@bruits/satteri-darwin-arm64': 0.9.2
-      '@bruits/satteri-darwin-x64': 0.9.2
-      '@bruits/satteri-linux-arm64-gnu': 0.9.2
-      '@bruits/satteri-linux-arm64-musl': 0.9.2
-      '@bruits/satteri-linux-x64-gnu': 0.9.2
-      '@bruits/satteri-linux-x64-musl': 0.9.2
-      '@bruits/satteri-wasm32-wasi': 0.9.2
-      '@bruits/satteri-win32-arm64-msvc': 0.9.2
-      '@bruits/satteri-win32-x64-msvc': 0.9.2
+      '@bruits/satteri-darwin-arm64': 0.9.4
+      '@bruits/satteri-darwin-x64': 0.9.4
+      '@bruits/satteri-linux-arm64-gnu': 0.9.4
+      '@bruits/satteri-linux-arm64-musl': 0.9.4
+      '@bruits/satteri-linux-x64-gnu': 0.9.4
+      '@bruits/satteri-linux-x64-musl': 0.9.4
+      '@bruits/satteri-wasm32-wasi': 0.9.4
+      '@bruits/satteri-win32-arm64-msvc': 0.9.4
+      '@bruits/satteri-win32-x64-msvc': 0.9.4
 
   sax@1.6.0: {}
 
@@ -27753,6 +27891,17 @@ snapshots:
       '@shikijs/engine-oniguruma': 1.17.7
       '@shikijs/types': 1.17.7
       '@shikijs/vscode-textmate': 9.3.1
+      '@types/hast': 3.0.4
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
   shiki@4.2.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2724,9 +2724,6 @@ importers:
 
   packages/mdx:
     dependencies:
-      '@fumadocs/satteri':
-        specifier: workspace:*
-        version: link:../satteri
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1
@@ -2776,6 +2773,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@fumadocs/satteri':
+        specifier: workspace:*
+        version: link:../satteri
       '@fumadocs/vite':
         specifier: workspace:*
         version: link:../vite
@@ -3440,12 +3440,6 @@ importers:
       satteri:
         specifier: ^0.9.4
         version: 0.9.4
-      unified:
-        specifier: ^11.0.5
-        version: 11.0.5
-      vfile:
-        specifier: ^6.0.3
-        version: 6.0.3
     devDependencies:
       '@types/estree':
         specifier: ^1.0.9


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`@fumadocs/satteri`**: `rehype-code` is now a native Satteri hast plugin (uses fumadocs-core Shiki via `defineHastPlugin` + `ctx.replaceNode`). Dropped `unified`/`vfile` from package deps. Unwraps Shiki `root` fragments before replacement.
- **`fumadocs-mdx`**: Satteri is opt-in — `@fumadocs/satteri` and `satteri` are optional peer dependencies. Main `config`/`build` bundles no longer import Satteri.
- **New entry points**:
  - `fumadocs-mdx/satteri` — `buildSatteriMDX`, `getSatteriOptions`
  - `fumadocs-mdx/config/satteri` — typed config helpers (`defineSatteriCollections`, `defineSatteriConfig`, `SatteriPresetOptions`)
- **Routing**: `buildMDX` dynamically imports `fumadocs-mdx/satteri` only when `compiler: 'satteri'`.
- **Tests**: `packages/satteri/test/rehype-code.test.ts` and `packages/mdx/test/satteri.test.ts`.

## Usage (Satteri opt-in)

```ts
import { defineCollections } from 'fumadocs-mdx/config';
import { defineSatteriConfig } from 'fumadocs-mdx/config/satteri';

export default {
  docs: defineCollections({
    type: 'doc',
    compiler: 'satteri',
    dir: 'content/docs',
  }),
  default: defineSatteriConfig({ /* satteriOptions */ }),
};
```

Install peers: `pnpm add @fumadocs/satteri satteri`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d61e099-b4cd-4169-8636-239786d7b279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d61e099-b4cd-4169-8636-239786d7b279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

