### PR TITLE
Add Rust codegen to OpenAPI examples

### DIFF
--- a/.tegami/2026-06-30-mr0tjxke.md
+++ b/.tegami/2026-06-30-mr0tjxke.md
@@ -1,0 +1,5 @@
+---
+packages: {}
+---
+
+## Add Rust codegen for OpenAPI examples

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -27,6 +27,7 @@
     "./requests/generators/java": "./dist/requests/generators/java.js",
     "./requests/generators/javascript": "./dist/requests/generators/javascript.js",
     "./requests/generators/python": "./dist/requests/generators/python.js",
+    "./requests/generators/rust": "./dist/requests/generators/rust.js",
     "./scalar": "./dist/scalar/index.js",
     "./server": "./dist/server/index.js",
     "./ui": "./dist/ui/index.js",

--- a/packages/openapi/src/requests/generators/all.ts
+++ b/packages/openapi/src/requests/generators/all.ts
@@ -5,6 +5,7 @@ import { go } from './go';
 import { java } from './java';
 import { javascript } from './javascript';
 import { python } from './python';
+import { rust } from './rust';
 
 export function registerDefault(registry: CodeUsageGeneratorRegistry) {
   registry.add('curl', curl);
@@ -13,5 +14,6 @@ export function registerDefault(registry: CodeUsageGeneratorRegistry) {
   registry.add('python', python);
   registry.add('java', java);
   registry.add('csharp', csharp);
+  registry.add('rust', rust);
   return registry;
 }

--- a/packages/openapi/src/requests/generators/rust.ts
+++ b/packages/openapi/src/requests/generators/rust.ts
@@ -45,7 +45,7 @@ ${
           .map(([key, value]) => `  .header("${key}", ${value})`)
           .join('\n'),
       ) + '\n'
-}    .send()
+}${body ? '    .body(body)\n' : ''}    .send()
     .await?
     .text()
     .await?;

--- a/packages/openapi/src/requests/generators/rust.ts
+++ b/packages/openapi/src/requests/generators/rust.ts
@@ -1,0 +1,57 @@
+import { doubleQuote, indent } from '@/requests/string-utils';
+import type { CodeUsageGenerator } from '@/requests/generators';
+import { MediaContext, resolveMediaAdapter } from '@/requests/media/adapter';
+
+export const rust: CodeUsageGenerator = {
+  label: 'Rust',
+  lang: 'rust',
+  generate(data, { mediaAdapters }) {
+    const headers = new Map<string, string>();
+
+    for (const header in data.header) {
+      headers.set(header, doubleQuote(data.header[header].value));
+    }
+
+    const cookies = Object.entries(data.cookie);
+    if (cookies.length > 0) {
+      headers.set(
+        'Cookie',
+        doubleQuote(cookies.map(([k, param]) => `${k}=${param.value}`).join('; ')),
+      );
+    }
+
+    let body: string | undefined;
+
+    if (data.body && data.bodyMediaType) {
+      const adapter = resolveMediaAdapter(data.bodyMediaType, mediaAdapters);
+      headers.set('Content-Type', `"${data.bodyMediaType}"`);
+      body = adapter?.generateExample(data as { body: unknown }, { lang: 'rust' } as MediaContext);
+    }
+
+    return `use reqwest::{Result, Client};
+
+async fn main() -> Result<()> {
+  let client = Client::new();
+
+  let url = "${data.url}";
+${body ? indent(body) + '\n' : ''}
+  let res = client
+    .${data.method.toLowerCase()}(url)
+${
+  headers.size <= 0
+    ? ''
+    : indent(
+        Array.from(headers.entries())
+          .map(([key, value]) => `  .header("${key}", ${value})`)
+          .join('\n'),
+      ) + '\n'
+}    .send()
+    .await?
+    .text()
+    .await?;
+
+  println!("{}", res);
+  Ok(())
+}`;
+  },
+};

--- a/packages/openapi/src/requests/media/adapter.ts
+++ b/packages/openapi/src/requests/media/adapter.ts
@@ -255,4 +255,8 @@ function str(
 
     return `var body = new StringContent(${tripleDoubleQuote(input)}, Encoding.UTF8, "${mediaType}");`;
   }
+
+  if (ctx.lang === 'rust') {
+    return `let body = r#"${inputToString(init, mediaType)}"#;`;
+  }
 }

--- a/packages/openapi/src/requests/media/adapter.ts
+++ b/packages/openapi/src/requests/media/adapter.ts
@@ -1,4 +1,9 @@
-import { backtickQuote, inputToString, tripleDoubleQuote } from '@/requests/string-utils';
+import {
+  backtickQuote,
+  inputToString,
+  rustRawStringLiteral,
+  tripleDoubleQuote,
+} from '@/requests/string-utils';
 export { resolveMediaAdapter, isMediaTypeSupported } from './resolve-adapter';
 // @ts-expect-error -- untyped
 import js2xml from 'xml-js/lib/js2xml';
@@ -257,6 +262,6 @@ function str(
   }
 
   if (ctx.lang === 'rust') {
-    return `let body = r#"${inputToString(init, mediaType)}"#;`;
+    return `let body = ${rustRawStringLiteral(inputToString(init, mediaType))};`;
   }
 }

--- a/packages/openapi/src/requests/string-utils.ts
+++ b/packages/openapi/src/requests/string-utils.ts
@@ -71,6 +71,20 @@ export function backtickQuote(str: string): string {
   return `\`${str.replace(/\\/g, '\\\\').replace(/`/g, '\\`')}\``;
 }
 
+/**
+ * Returns the input string wrapped inside a Rust string literal,
+ * with increasing number of # to escape `"#`
+ */
+export function rustRawStringLiteral(str: string): string {
+  let hashes = '#';
+
+  while (str.includes(`"${hashes}`)) {
+    hashes += '#';
+  }
+
+  return `r${hashes}"${str}"${hashes}`;
+}
+
 export function indent(code: string, tab: number = 1) {
   const p = '  '.repeat(tab);
   return code


### PR DESCRIPTION
## Summary
This PR adds the Rust language in the OpenAPI examples 

## Related Issues
None

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
POST example request:
<img width="419" height="527" alt="image" src="https://github.com/user-attachments/assets/9fa04fa2-3547-4abe-bbaa-53f873b446e7" />

GET example request:
<img width="428" height="406" alt="image" src="https://github.com/user-attachments/assets/c4b2266e-c7e7-426a-85d1-66592986989e" />

## Additional Context
Rust doesn't have a native way of making HTTP requests, so it relies on third party libraries. The generated examples use the `reqwest` crate (the most popular HTTP library in Rust) to make the HTTP requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rust request generation for OpenAPI examples, including Rust `reqwest` sample code.
  * Rust output is now exposed as a supported export and included in the default generator set.
  * Improved Rust request-body rendering and raw string literal handling, including correct header and cookie formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->