### PR TITLE
feat(base-ui): updated the theme switch to use `document.startViewTransition()`

### DIFF
--- a/.tegami/2026-07-02-mr2nfni8.md
+++ b/.tegami/2026-07-02-mr2nfni8.md
@@ -1,0 +1,6 @@
+---
+packages:
+  npm:@fumadocs/base-ui: patch
+---
+
+## Updated the theme switch to use `document.startViewTransition()` for smoother theme transitions with graceful fallback.

--- a/.tegami/2026-07-02-mr2nfni8.md
+++ b/.tegami/2026-07-02-mr2nfni8.md
@@ -1,6 +1,7 @@
 ---
 packages:
   npm:@fumadocs/base-ui: patch
+  npm:fumadocs-ui: patch
 ---
 
 ## Updated the theme switch to use `document.startViewTransition()` for smoother theme transitions with graceful fallback.

--- a/packages/base-ui/src/layouts/shared/slots/theme-switch.tsx
+++ b/packages/base-ui/src/layouts/shared/slots/theme-switch.tsx
@@ -3,6 +3,7 @@ import { cva } from 'class-variance-authority';
 import { Airplay, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { type ComponentProps, useEffect, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { cn } from '@/utils/cn';
 import { useTranslations } from '@fuma-translate/react';
 
@@ -33,7 +34,7 @@ export function ThemeSwitch({ className, mode = 'light-dark', ...props }: ThemeS
 
   const handleThemeChange = (newTheme: string) => {
     if (document?.startViewTransition) {
-      document.startViewTransition(() => setTheme(newTheme));
+      document.startViewTransition(() => flushSync(() => setTheme(newTheme)));
     } else {
       setTheme(newTheme);
     }

--- a/packages/base-ui/src/layouts/shared/slots/theme-switch.tsx
+++ b/packages/base-ui/src/layouts/shared/slots/theme-switch.tsx
@@ -31,6 +31,14 @@ export function ThemeSwitch({ className, mode = 'light-dark', ...props }: ThemeS
     system: t('System', { note: 'aria-label' }),
   };
 
+  const handleThemeChange = (newTheme: string) => {
+    if (document?.startViewTransition) {
+      document.startViewTransition(() => setTheme(newTheme));
+    } else {
+      setTheme(newTheme);
+    }
+  };
+
   useEffect(() => {
     setMounted(true);
   }, []);
@@ -47,7 +55,7 @@ export function ThemeSwitch({ className, mode = 'light-dark', ...props }: ThemeS
       <button
         className={container}
         aria-label={t('Toggle Theme', { note: 'aria-label' })}
-        onClick={() => setTheme(value === 'light' ? 'dark' : 'light')}
+        onClick={() => handleThemeChange(value === 'light' ? 'dark' : 'light')}
         data-theme-toggle=""
       >
         {themes.map(([key, Icon]) => {
@@ -72,21 +80,21 @@ export function ThemeSwitch({ className, mode = 'light-dark', ...props }: ThemeS
       <button
         aria-label={themeAriaLabels.light}
         className={cn(itemVariants({ active: value === 'light' }))}
-        onClick={() => setTheme('light')}
+        onClick={() => handleThemeChange('light')}
       >
         <Sun className="size-full" fill="currentColor" />
       </button>
       <button
         aria-label={themeAriaLabels.dark}
         className={cn(itemVariants({ active: value === 'dark' }))}
-        onClick={() => setTheme('dark')}
+        onClick={() => handleThemeChange('dark')}
       >
         <Moon className="size-full" fill="currentColor" />
       </button>
       <button
         aria-label={themeAriaLabels.system}
         className={cn(itemVariants({ active: value === 'system' }))}
-        onClick={() => setTheme('system')}
+        onClick={() => handleThemeChange('system')}
       >
         <Airplay className="size-full" fill="currentColor" />
       </button>

--- a/packages/radix-ui/src/layouts/shared/slots/theme-switch.tsx
+++ b/packages/radix-ui/src/layouts/shared/slots/theme-switch.tsx
@@ -3,6 +3,7 @@ import { cva } from 'class-variance-authority';
 import { Airplay, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { type ComponentProps, useEffect, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { cn } from '@/utils/cn';
 import { useTranslations } from '@fuma-translate/react';
 
@@ -31,6 +32,14 @@ export function ThemeSwitch({ className, mode = 'light-dark', ...props }: ThemeS
     system: t('System', { note: 'aria-label' }),
   };
 
+  const handleThemeChange = (newTheme: string) => {
+    if (document?.startViewTransition) {
+      document.startViewTransition(() => flushSync(() => setTheme(newTheme)));
+    } else {
+      setTheme(newTheme);
+    }
+  };
+
   useEffect(() => {
     setMounted(true);
   }, []);
@@ -47,7 +56,7 @@ export function ThemeSwitch({ className, mode = 'light-dark', ...props }: ThemeS
       <button
         className={container}
         aria-label={t('Toggle Theme', { note: 'aria-label' })}
-        onClick={() => setTheme(value === 'light' ? 'dark' : 'light')}
+        onClick={() => handleThemeChange(value === 'light' ? 'dark' : 'light')}
         data-theme-toggle=""
       >
         {full.map(([key, Icon]) => {
@@ -74,7 +83,7 @@ export function ThemeSwitch({ className, mode = 'light-dark', ...props }: ThemeS
           key={key}
           aria-label={themeAriaLabels[key]}
           className={cn(itemVariants({ active: value === key }))}
-          onClick={() => setTheme(key)}
+          onClick={() => handleThemeChange(key)}
         >
           <Icon className="size-full" fill="currentColor" />
         </button>


### PR DESCRIPTION
## Summary
Update the theme switch to use `document.startViewTransition()` for smoother theme transitions.

Recently add a gif theme transition after reading https://theme-toggle.rdsx.dev/ and i have to clone the fumadocs switch just to add the `startViewTransition` on it.

## Type of Change
- [ ] Bug fix
- [ x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [ x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme switching now leverages smoother browser view transitions when supported, improving the visual polish of theme changes.
  * If view transitions aren’t available, theme updates fall back to the standard behavior to ensure consistent functionality.
* **Chores**
  * Pinned certain UI package versions to patch-level updates to keep changes small and controlled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->