### PR TITLE
fix(base-ui): render Home layout nav list as div for valid list semantics

### DIFF
--- a/.tegami/2026-07-17-navlist-a11y.md
+++ b/.tegami/2026-07-17-navlist-a11y.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@fumadocs/base-ui:
+    type: patch
+---
+
+## Fix invalid list semantics in Home layout navbar
+
+`NavigationMenu.List` in the Home layout header defaults to a `<ul>`, but its direct children (nav title link, link groups, control clusters) are not `<li>` elements, which is an accessibility violation (axe `list`, serious) on every page using `HomeLayout`. Render it as a `<div>` instead — the same intent as the Radix UI variant, which already renders its list as a non-`<ul>` element via `asChild`.

--- a/packages/base-ui/src/layouts/home/slots/header.tsx
+++ b/packages/base-ui/src/layouts/home/slots/header.tsx
@@ -81,6 +81,9 @@ export function Header(props: ComponentProps<'header'>) {
   const list = (
     <Primitive.List
       ref={listRef}
+      // defaults to <ul>, but its children (nav title, link groups, controls) are not <li> —
+      // render a <div> for valid list semantics, like the Radix UI variant does with `asChild`
+      render={<div />}
       className="flex h-14 w-full mx-auto max-w-(--fd-layout-width) items-center px-4"
     >
       {slots.navTitle && (


### PR DESCRIPTION
## Summary

Renders the Home layout header's `NavigationMenu.List` as a `<div>` via the base-ui `render` prop.

The list defaults to a `<ul>`, but its direct children (nav title link, link groups, control clusters) are not `<li>` elements, which produces an axe **`list` violation (serious)** on every page using `HomeLayout` (WCAG 1.3.1 — screen readers misannounce the list structure). The actual menu items keep their semantics: they already live inside proper inner `<ul>`/`<li>` structures.

This mirrors the Radix UI variant, which already renders its list as a non-`<ul>` element (`<NavigationMenuList asChild><nav>` in `packages/radix-ui/src/layouts/home/slots/header.tsx`).

## Related Issues

Closes #3422

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project (`oxfmt`)
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

No pixel changes — semantics only. Rendered markup before/after:

```html
<!-- before -->
<ul class="flex h-14 w-full mx-auto max-w-(--fd-layout-width) items-center px-4">
  <a …>…</a>
  <ul …>…</ul>
  <div …>…</div>
  <div …>…</div>
</ul>

<!-- after -->
<div class="flex h-14 w-full mx-auto max-w-(--fd-layout-width) items-center px-4">
  <a …>…</a>
  <ul …>…</ul>
  <div …>…</div>
  <div …>…</div>
</div>
```

axe result on pages using `HomeLayout`: `list (serious)` → no violations.

## Additional Context

- Verified locally: `types:check`, `oxlint`, package build, and the monorepo test suite (`vitest run`, 244 passed).
- Also verified at runtime on a production site running the patched build: dropdown open/close and keyboard behavior unchanged; axe clean across all routes in both light and dark themes (headless Chrome + axe-core 4.12).
- Changelog entry included (`patch` for `@fumadocs/base-ui`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation accessibility by rendering the desktop navigation container with valid semantic markup.
  * Resolved serious list-structure issues detected by accessibility checks across pages using the Home layout.

* **Documentation**
  * Added a release note documenting the navigation accessibility improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->