### PR TITLE
Fix Tanstack Start `$.tsx` example

### DIFF
--- a/examples/tanstack-start-min/src/routes/docs/$.tsx
+++ b/examples/tanstack-start-min/src/routes/docs/$.tsx
@@ -36,7 +36,7 @@ function Content({ path }: { path: string }) {
   const page = docs.getPage(path);
   if (!page) throw new Error(`unknown page: ${path}`);
 
-  const { toc } = use(page.load());
+  const toc = page.toc;
   const MDX = page.body;
 
   return (

--- a/examples/tanstack-start-min/src/routes/docs/$.tsx
+++ b/examples/tanstack-start-min/src/routes/docs/$.tsx
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/docs/$')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .validator((slugs: string[]) => slugs)
+  .inputValidator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs);
     if (!page) throw notFound();


### PR DESCRIPTION
## Summary
Fix Tanstack Start `$.tsx` example. It's possible that the example followed an older version of the library.

Edit: also fixed `validator()` (it's `inputValidator()` in Tanstack Start now).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): docs fix

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table-of-contents rendering in the documentation pages by using the resolved page content directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->