### PR TITLE
fix(ui): guard against undefined options in DynamicCodeBlock

### DIFF
--- a/.tegami/2026-08-06-dyncodeblock-options.md
+++ b/.tegami/2026-08-06-dyncodeblock-options.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:fumadocs-ui: patch
+  npm:@fumadocs/base-ui: patch
+---
+
+## Fix crash in `DynamicCodeBlock` when `options` is undefined
+
+`DynamicCodeBlock` read `options.components` unconditionally while building its Shiki config, even though `options` is optional on the public wrapper component. Passing an explicit `options={undefined}` (e.g. a value forwarded from another optional prop) crashed with `Cannot read properties of undefined (reading 'components')` instead of falling back to the default `pre` renderer.
+
+`options` is now read with optional chaining, so an undefined `options` behaves the same as omitting the prop entirely.

--- a/packages/base-ui/src/components/dynamic-codeblock.core.tsx
+++ b/packages/base-ui/src/components/dynamic-codeblock.core.tsx
@@ -57,7 +57,7 @@ export function DynamicCodeBlock({
     ...options,
     components: {
       pre: DefaultPre,
-      ...options.components,
+      ...options?.components,
     },
   };
   let node = useShikiDynamic(highlighter, code, shikiOptions, [id, lang, code]);

--- a/packages/radix-ui/src/components/dynamic-codeblock.core.tsx
+++ b/packages/radix-ui/src/components/dynamic-codeblock.core.tsx
@@ -57,7 +57,7 @@ export function DynamicCodeBlock({
     ...options,
     components: {
       pre: DefaultPre,
-      ...options.components,
+      ...options?.components,
     },
   };
   let node = useShikiDynamic(highlighter, code, shikiOptions, [id, lang, code]);


### PR DESCRIPTION
## Summary

`DynamicCodeBlock`'s core implementation read `options.components` unconditionally when building its Shiki config, even though `options` is typed as optional on the public wrapper component (`fumadocs-ui/components/dynamic-codeblock` and `@fumadocs/base-ui`'s equivalent). Passing an explicit `options={undefined}` — for example when forwarding an optional prop from a consumer's own component — throws:

```
TypeError: Cannot read properties of undefined (reading 'components')
```

instead of falling back to the default `pre` renderer, as happens when the prop is omitted entirely.

## Fix

Read `options?.components` instead of `options.components` in both `dynamic-codeblock.core.tsx` implementations (`packages/base-ui` and `packages/radix-ui`).

## Test plan

- [x] `pnpm run build --filter='./packages/*'`
- [x] `pnpm run types:check --filter='@fumadocs/base-ui' --filter='fumadocs-ui'`
- [x] `pnpm run lint --filter='@fumadocs/base-ui' --filter='fumadocs-ui'`
- [x] `oxfmt --check` on changed files
- [x] Added a `tegami` changelog entry (`pnpm tegami`) for both affected packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where code blocks could fail when no rendering options were provided.
  - Preserved the default code block rendering while continuing to support custom component overrides.

- **Documentation**
  - Added release notes describing the improved handling of optional code block settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->