### PR TITLE
perf(openapi): avoid recreating proxies for every generated page

### DIFF
--- a/.tegami/2026-08-13-reuse-openapi-proxy.md
+++ b/.tegami/2026-08-13-reuse-openapi-proxy.md
@@ -1,0 +1,8 @@
+---
+packages:
+  npm:fumadocs-openapi: patch
+---
+
+## Improve OpenAPI source generation performance
+
+Reuse the JSON Magic proxy while generating static data for pages from the same OpenAPI document.

--- a/packages/openapi/src/utils/pages/to-static-data.ts
+++ b/packages/openapi/src/utils/pages/to-static-data.ts
@@ -7,6 +7,8 @@ import { idToTitle } from '@fumadocs/api-docs/utils/id-to-title';
 import { dereferenceShallow } from '@fumadocs/api-docs/schema/dereference';
 import { createMagicProxy } from '@scalar/json-magic/magic-proxy';
 
+const proxyCache = new WeakMap<Document, Document>();
+
 export function toStaticData(
   page: GeneratedPageProps,
   doc: Document,
@@ -14,7 +16,11 @@ export function toStaticData(
   toc: TOCItemType[];
   structuredData: StructuredData;
 } {
-  const proxied = createMagicProxy(doc as Record<string, unknown>) as Document;
+  let proxied = proxyCache.get(doc);
+  if (!proxied) {
+    proxied = createMagicProxy(doc as Record<string, unknown>) as Document;
+    proxyCache.set(doc, proxied);
+  }
   const slugger = new Slugger();
   const toc: TOCItemType[] = [];
   const structuredData: StructuredData = { headings: [], contents: [] };

--- a/packages/openapi/test/to-static-data.test.ts
+++ b/packages/openapi/test/to-static-data.test.ts
@@ -1,0 +1,36 @@
+import { createMagicProxy } from '@scalar/json-magic/magic-proxy';
+import { expect, test, vi } from 'vitest';
+import type { Document } from '@/types';
+import { toStaticData } from '@/utils/pages/to-static-data';
+
+vi.mock('@scalar/json-magic/magic-proxy', () => ({
+  createMagicProxy: vi.fn((document: Record<string, unknown>) => document),
+}));
+
+test('reuses the magic proxy for the same document', () => {
+  const document: Document = {
+    openapi: '3.2.0',
+    info: { title: 'Test', version: '1.0.0' },
+    paths: {
+      '/users': {
+        get: {
+          responses: {},
+          summary: 'List users',
+        },
+      },
+    },
+  };
+  const page = {
+    document: 'test',
+    operations: [{ path: '/users', method: 'get' as const }],
+  };
+  const otherDocument = { ...document };
+
+  toStaticData(page, document);
+  toStaticData(page, document);
+  toStaticData(page, otherDocument);
+
+  expect(createMagicProxy).toHaveBeenCalledTimes(2);
+  expect(createMagicProxy).toHaveBeenCalledWith(document);
+  expect(createMagicProxy).toHaveBeenCalledWith(otherDocument);
+});


### PR DESCRIPTION
## Summary

When `fumadocs-openapi` generates per-operation pages, each page calls
`toStaticData()` with the same bundled document.

In our project, a 4.9 MB Telegram OpenAPI schema generates 748 pages, recreating
the same JSON Magic proxy 748 times. Reusing one proxy per document reduced
generation time from 4,991 ms to 62 ms.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

N/A

## Additional Context

I used AI while working on this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved static page-data generation by reusing processing resources for repeated requests involving the same OpenAPI document.

* **Bug Fixes**
  * Ensured separate OpenAPI documents are processed independently.

* **Tests**
  * Added coverage validating resource reuse for identical documents and separation for distinct documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->