### PR TITLE
feat: add @fumadocs/local-html content source

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -24,6 +24,7 @@
     "packages/mdx-remote/test/fixtures/**/*.js",
     "packages/mdx-remote/test/fixtures/**/*.json",
     "packages/local-md/test/fixtures/**/*.json",
+    "packages/local-html/test/fixtures/**/*.json",
     "packages/core/test/fixtures/page-trees/**/*.json",
 
     "routeTree.gen.ts",

--- a/.tegami/2026-08-13-local-html.md
+++ b/.tegami/2026-08-13-local-html.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@fumadocs/local-html:
+    type: minor
+---
+
+## New package: `@fumadocs/local-html`
+
+A content source for local HTML files. It integrates externally-produced HTML pages (exported decks, reports, agent-generated deliverables) into a Fumadocs site, adapting them to the docs theme: content is scoped to `<main>`/`<article>`, page chrome and scripts/styles are dropped, `class`/`style` attributes are removed so prose styling takes over, and headings get generated ids for TOC and search indexing.

--- a/apps/docs/content/docs/(framework)/integrations/content/local-html.mdx
+++ b/apps/docs/content/docs/(framework)/integrations/content/local-html.mdx
@@ -1,0 +1,141 @@
+---
+title: Local HTML
+description: Content source for local HTML files.
+---
+
+## Introduction
+
+`@fumadocs/local-html` is a content source for local HTML files. It integrates pages produced outside your docs pipeline — exported decks, reports, agent-generated deliverables, output of other tools — and adapts them to your docs theme.
+
+For each `.html` file, it:
+
+- scopes the content to `<main>`/`<article>` (falling back to `<body>`), dropping page chrome like `<header>`, `<footer>` and `<nav>`, along with `<script>` and `<style>` tags.
+- removes `class` and `style` attributes by default, so your docs theme's prose styling takes over.
+- generates ids for headings, powering the table of contents and search indexing.
+- reads the page title and description from `<title>` and `<meta>` tags.
+
+As compared to [Local Markdown](/docs/integrations/content/local-md), it is for content you receive as HTML rather than author as Markdown — the HTML is treated as data to adapt, not as a document format to write in.
+
+### Limitations
+
+- Scripts are stripped: interactive behaviour of the original page is not preserved.
+- No MDX components in content, but you can map HTML tags to custom components at render phase.
+
+## Setup
+
+Install the package:
+
+```package-install
+@fumadocs/local-html
+```
+
+Create a `localHtml` instance and connect it to Fumadocs:
+
+```ts title="lib/source.ts"
+import { dynamicLoader } from 'fumadocs-core/source/dynamic';
+import { localHtml } from '@fumadocs/local-html';
+
+const pages = localHtml({
+  dir: 'content/pages',
+  // options
+});
+
+const pagesLoader = dynamicLoader(pages.dynamicSource(), {
+  baseUrl: '/docs',
+});
+
+export async function getSource() {
+  return pagesLoader.get();
+}
+```
+
+You can use `staticSource()` with a normal `loader()` when you only need a one-time snapshot without revalidation:
+
+```ts title="lib/source.ts"
+import { loader } from 'fumadocs-core/source';
+import { localHtml } from '@fumadocs/local-html';
+
+const pages = localHtml({
+  dir: 'content/pages',
+});
+
+export const source = loader(await pages.staticSource(), {
+  baseUrl: '/docs',
+});
+```
+
+### Page Metadata
+
+The title and description of each page are read from its `<head>`:
+
+- `<title>` becomes the page title.
+- `<meta name="description">` becomes the description.
+
+You can override them (and set an icon) without touching the visible content, using `fumadocs:` metas:
+
+```html
+<meta name="fumadocs:title" content="My Page" />
+<meta name="fumadocs:description" content="A short description." />
+<meta name="fumadocs:icon" content="Album" />
+```
+
+Every `<meta name>`/`content` pair of the document is also available on `page.data.metadata`.
+
+Like other local sources, `meta.json` files customize the page tree, validated with `metaSchema`.
+
+### Content Options
+
+```ts
+import { localHtml } from '@fumadocs/local-html';
+
+const pages = localHtml({
+  dir: 'content/pages',
+  // keep the original class/style attributes instead of adapting to your theme
+  adaptStyles: false,
+  // drop additional tags from the content
+  exclude: ['iframe'],
+  // custom logic to pick the element holding the page content
+  selectContent: (root) => {
+    // return a hast element, or undefined for the default behaviour
+  },
+});
+```
+
+## Rendering
+
+`page.data.load()` returns a renderer with the processed content:
+
+```tsx title="app/docs/[[...slug]]/page.tsx"
+import { source } from '@/lib/source';
+import { DocsPage, DocsBody, DocsTitle, DocsDescription } from 'fumadocs-ui/page';
+import { notFound } from 'next/navigation';
+
+export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
+  const params = await props.params;
+  const page = source.getPage(params.slug);
+  if (!page) notFound();
+
+  const renderer = await page.data.load();
+  const { body, toc } = await renderer.render();
+
+  return (
+    <DocsPage toc={toc}>
+      <DocsTitle>{page.data.title}</DocsTitle>
+      <DocsDescription>{page.data.description}</DocsDescription>
+      <DocsBody>{body}</DocsBody>
+    </DocsPage>
+  );
+}
+```
+
+You can map HTML tags to your own components, like headings with anchors:
+
+```tsx
+import { getMDXComponents } from '@/mdx-components';
+
+const { body, toc } = await renderer.render(getMDXComponents());
+```
+
+## Search
+
+The processed content exposes `structuredData` compatible with [Search](/docs/headless/search), built from the headings and text blocks of the page — no extra work is needed to index HTML pages.

--- a/packages/local-html/README.md
+++ b/packages/local-html/README.md
@@ -1,0 +1,16 @@
+# Fumadocs Local HTML
+
+The local HTML files content source for Fumadocs. It integrates plain `.html` files — exported decks, reports, agent-generated deliverables, pages from other tools — into a Fumadocs site, adapting them to the docs theme:
+
+- content is scoped to `<main>`/`<article>` (page chrome, scripts and styles are dropped),
+- `class`/`style` attributes are removed by default so the docs prose styling takes over,
+- headings get generated ids, powering the table of contents and search indexing,
+- `<title>` and `<meta>` tags become the page's title/description (`fumadocs:title`, `fumadocs:description` and `fumadocs:icon` metas take precedence).
+
+```ts
+import { localHtml } from '@fumadocs/local-html';
+
+const source = localHtml({ dir: 'content/pages' });
+```
+
+See [the documentation](https://fumadocs.dev) for details.

--- a/packages/local-html/README.md
+++ b/packages/local-html/README.md
@@ -7,10 +7,12 @@ The local HTML files content source for Fumadocs. It integrates plain `.html` fi
 - headings get generated ids, powering the table of contents and search indexing,
 - `<title>` and `<meta>` tags become the page's title/description (`fumadocs:title`, `fumadocs:description` and `fumadocs:icon` metas take precedence).
 
+Trust model: content is transformed, not sanitized. `<script>`, `<style>`, `<iframe>`, `<object>`, `<embed>` and inline event handlers are always dropped, but the remaining markup (links, images, attributes) is rendered as-is — treat the content directory like you treat your Markdown content: local files you trust.
+
 ```ts
 import { localHtml } from '@fumadocs/local-html';
 
 const source = localHtml({ dir: 'content/pages' });
 ```
 
-See [the documentation](https://fumadocs.dev) for details.
+See [the documentation](https://fumadocs.dev/docs/integrations/content/local-html) for details.

--- a/packages/local-html/package.json
+++ b/packages/local-html/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@fumadocs/local-html",
+  "version": "0.0.1",
+  "description": "The local HTML files content source for Fumadocs",
+  "keywords": [
+    "Docs",
+    "fumadocs"
+  ],
+  "homepage": "https://fumadocs.dev",
+  "license": "MIT",
+  "author": "Fuma Nama",
+  "repository": "github:fuma-nama/fumadocs",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./client": "./dist/client.js",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "clean": "rimraf dist",
+    "dev": "tsdown --watch",
+    "lint": "oxlint .",
+    "test": "vitest run",
+    "types:check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@fumadocs/local-content": "workspace:*",
+    "@standard-schema/spec": "^1.1.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-jsx-runtime": "^2.3.6",
+    "unist-util-visit": "^5.1.0",
+    "vfile": "^6.0.3"
+  },
+  "devDependencies": {
+    "@types/hast": "^3.0.5",
+    "@types/node": "26.2.0",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "fumadocs-core": "workspace:*",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "tsconfig": "workspace:*",
+    "tsdown": "0.22.14",
+    "unified": "^11.0.5"
+  },
+  "peerDependencies": {
+    "@types/hast": "*",
+    "@types/react": "*",
+    "fumadocs-core": "^16.8.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "unified": "*"
+  },
+  "peerDependenciesMeta": {
+    "@types/hast": {
+      "optional": true
+    },
+    "@types/react": {
+      "optional": true
+    },
+    "unified": {
+      "optional": true
+    }
+  }
+}

--- a/packages/local-html/package.json
+++ b/packages/local-html/package.json
@@ -55,18 +55,13 @@
     "@types/hast": "*",
     "@types/react": "*",
     "fumadocs-core": "^16.8.0",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
-    "unified": "*"
+    "react": "^19.2.0"
   },
   "peerDependenciesMeta": {
     "@types/hast": {
       "optional": true
     },
     "@types/react": {
-      "optional": true
-    },
-    "unified": {
       "optional": true
     }
   }

--- a/packages/local-html/src/client.ts
+++ b/packages/local-html/src/client.ts
@@ -1,0 +1,1 @@
+export { fromSerialized as rendererFromSerialized } from './html/renderer';

--- a/packages/local-html/src/html/compiler.ts
+++ b/packages/local-html/src/html/compiler.ts
@@ -34,7 +34,7 @@ export interface ProcessedHtml {
   structuredData: StructuredData;
 }
 
-/** tags that never carry readable content */
+/** tags that never carry readable content, or that can embed external/executable content */
 const NonContentTags = new Set([
   'script',
   'style',
@@ -44,6 +44,9 @@ const NonContentTags = new Set([
   'meta',
   'title',
   'base',
+  'iframe',
+  'object',
+  'embed',
 ]);
 
 /** page chrome, dropped only when no `<main>`/`<article>` scopes the content */
@@ -107,13 +110,21 @@ export function processHtml(input: Root, options: ProcessHtmlOptions = {}): Proc
     content ??= findElement(input, 'body') ?? input;
   }
 
+  // the input tree may be cached and shared (e.g. `HtmlPage.tree`), never mutate it
   const tree: Root = {
     type: 'root',
-    children: content.type === 'root' ? content.children : content.children.slice(),
+    children: structuredClone(content.children),
   };
 
   const excluded = new Set(exclude);
   const slugger = new Slugger();
+
+  // seed the slugger with pre-existing heading ids, so generated ones cannot collide
+  visit(tree, 'element', (element) => {
+    if (HeadingTags.has(element.tagName) && typeof element.properties.id === 'string') {
+      slugger.slug(element.properties.id);
+    }
+  });
 
   visit(tree, 'element', (element, index, parent) => {
     if (

--- a/packages/local-html/src/html/compiler.ts
+++ b/packages/local-html/src/html/compiler.ts
@@ -1,0 +1,182 @@
+import { fromHtml } from 'hast-util-from-html';
+import { visit, SKIP } from 'unist-util-visit';
+import Slugger from 'github-slugger';
+import { rehypeToc, type RehypeTOCItemType } from 'fumadocs-core/mdx-plugins/rehype-toc';
+import type { StructuredData } from 'fumadocs-core/mdx-plugins';
+import { VFile } from 'vfile';
+import type { Element, Root } from 'hast';
+import type { Processor } from 'unified';
+
+export interface ProcessHtmlOptions {
+  /**
+   * pick the element holding the page content.
+   *
+   * by default: the first `<main>`, then `<article>`, then `<body>`, then the whole tree.
+   */
+  selectContent?: (root: Root) => Element | Root | undefined;
+
+  /**
+   * tag names to drop from the content, on top of the defaults
+   */
+  exclude?: string[];
+
+  /**
+   * remove `class` and `style` attributes so the content adapts to the docs theme
+   *
+   * @defaultValue true
+   */
+  adaptStyles?: boolean;
+}
+
+export interface ProcessedHtml {
+  tree: Root;
+  toc: RehypeTOCItemType[];
+  structuredData: StructuredData;
+}
+
+/** tags that never carry readable content */
+const NonContentTags = new Set([
+  'script',
+  'style',
+  'template',
+  'noscript',
+  'link',
+  'meta',
+  'title',
+  'base',
+]);
+
+/** page chrome, dropped only when no `<main>`/`<article>` scopes the content */
+const ChromeTags = new Set(['header', 'footer', 'nav', 'aside']);
+
+const HeadingTags = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+/** the smallest units of readable text, for search indexing */
+const TextBlockTags = new Set([
+  'p',
+  'li',
+  'td',
+  'th',
+  'figcaption',
+  'blockquote',
+  'pre',
+  'dt',
+  'dd',
+]);
+
+export function parseHtml(value: string): Root {
+  const head = value.slice(0, 1024);
+
+  return fromHtml(value, {
+    fragment: !/<!doctype|<html[\s>]/i.test(head),
+  });
+}
+
+export function textOf(node: Element | Root): string {
+  let out = '';
+
+  visit(node, 'text', (text) => {
+    out += text.value;
+  });
+
+  return out;
+}
+
+function findElement(root: Root, tagName: string): Element | undefined {
+  let found: Element | undefined;
+
+  visit(root, 'element', (element) => {
+    if (element.tagName === tagName) {
+      found = element;
+      return false;
+    }
+  });
+
+  return found;
+}
+
+export function processHtml(input: Root, options: ProcessHtmlOptions = {}): ProcessedHtml {
+  const { selectContent, exclude = [], adaptStyles = true } = options;
+
+  let content: Element | Root | undefined = selectContent?.(input);
+  let scoped = content !== undefined;
+
+  if (!content) {
+    content = findElement(input, 'main') ?? findElement(input, 'article');
+    scoped = content !== undefined;
+    content ??= findElement(input, 'body') ?? input;
+  }
+
+  const tree: Root = {
+    type: 'root',
+    children: content.type === 'root' ? content.children : content.children.slice(),
+  };
+
+  const excluded = new Set(exclude);
+  const slugger = new Slugger();
+
+  visit(tree, 'element', (element, index, parent) => {
+    if (
+      NonContentTags.has(element.tagName) ||
+      excluded.has(element.tagName) ||
+      (!scoped && ChromeTags.has(element.tagName))
+    ) {
+      if (parent && typeof index === 'number') parent.children.splice(index, 1);
+      return [SKIP, index];
+    }
+
+    for (const key of Object.keys(element.properties)) {
+      // inline event handlers never survive the transform
+      if (/^on./i.test(key)) delete element.properties[key];
+    }
+
+    if (adaptStyles) {
+      delete element.properties.className;
+      delete element.properties.style;
+    }
+
+    if (HeadingTags.has(element.tagName) && typeof element.properties.id !== 'string') {
+      const text = textOf(element).trim();
+      if (text.length > 0) element.properties.id = slugger.slug(text);
+    }
+  });
+
+  const file = new VFile();
+  const transform = rehypeToc.call(undefined as unknown as Processor, {
+    exportToc: { as: 'data' },
+  });
+  transform(tree, file, () => undefined);
+
+  return {
+    tree,
+    toc: file.data.rehypeToc ?? [],
+    structuredData: buildStructuredData(tree),
+  };
+}
+
+function buildStructuredData(tree: Root): StructuredData {
+  const data: StructuredData = { headings: [], contents: [] };
+  let heading: string | undefined;
+
+  visit(tree, 'element', (element) => {
+    if (HeadingTags.has(element.tagName)) {
+      const id = element.properties.id;
+
+      if (typeof id === 'string') {
+        data.headings.push({ id, content: textOf(element).trim() });
+        heading = id;
+      }
+
+      return SKIP;
+    }
+
+    if (TextBlockTags.has(element.tagName)) {
+      const content = textOf(element).trim();
+      if (content.length > 0) data.contents.push({ heading, content });
+
+      return SKIP;
+    }
+  });
+
+  return data;
+}

--- a/packages/local-html/src/html/renderer.ts
+++ b/packages/local-html/src/html/renderer.ts
@@ -1,0 +1,76 @@
+import type { TOCItemType } from 'fumadocs-core/toc';
+import type { RehypeTOCItemType, StructuredData } from 'fumadocs-core/mdx-plugins';
+import type { ReactNode } from 'react';
+import * as JsxRuntime from 'react/jsx-runtime';
+import { type Components, toJsxRuntime } from 'hast-util-to-jsx-runtime';
+import type { Root } from 'hast';
+
+export interface HtmlRenderer {
+  structuredData: StructuredData;
+  render: (components?: Partial<Components>) => Promise<HtmlRendererResult>;
+  renderSync: (components?: Partial<Components>) => HtmlRendererResult;
+  serialize: () => HtmlRendererOptions;
+}
+
+export interface HtmlRendererResult {
+  toc: TOCItemType[];
+  body: ReactNode;
+}
+
+export interface HtmlRendererOptions {
+  tree: Root;
+  filePath?: string;
+  structuredData?: StructuredData;
+  rehypeToc?: RehypeTOCItemType[];
+}
+
+export function fromAst(options: HtmlRendererOptions): HtmlRenderer {
+  const {
+    filePath,
+    structuredData = {
+      headings: [],
+      contents: [],
+    },
+    rehypeToc = [],
+    tree,
+  } = options;
+
+  function renderSync(components?: Partial<Components>): HtmlRendererResult {
+    function render(tree: Root): ReactNode {
+      return toJsxRuntime(tree, {
+        filePath,
+        components,
+        development: false,
+        ...JsxRuntime,
+      });
+    }
+
+    const toc = rehypeToc.map((item): TOCItemType => ({
+      ...item,
+      title: render({
+        type: 'root',
+        children: item.title.children,
+      }),
+    }));
+
+    return {
+      toc,
+      body: render(tree),
+    };
+  }
+
+  return {
+    structuredData,
+    renderSync,
+    async render(components) {
+      return renderSync(components);
+    },
+    serialize() {
+      return options;
+    },
+  };
+}
+
+export function fromSerialized(options: HtmlRendererOptions): HtmlRenderer {
+  return fromAst(options);
+}

--- a/packages/local-html/src/index.ts
+++ b/packages/local-html/src/index.ts
@@ -1,0 +1,77 @@
+import type { MetaData, DynamicSource, StaticSource } from 'fumadocs-core/source';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import {
+  createLocalSource,
+  type SourceOptions,
+  type WatchableSource,
+} from '@fumadocs/local-content';
+import { htmlIntegration, type HtmlPage } from './integration';
+import type * as defaultSchemas from 'fumadocs-core/source/schema';
+import { fromAst, type HtmlRenderer } from './html/renderer';
+import { processHtml, type ProcessHtmlOptions } from './html/compiler';
+
+export interface LocalHtmlConfig<MetaSchema extends StandardSchemaV1> extends ProcessHtmlOptions {
+  /** root directory for content files */
+  dir: string;
+  /** a list of glob patterns, customize the content files to be scanned */
+  include?: string[];
+  metaSchema?: MetaSchema;
+}
+
+export interface LocalHtml<MetaSchema extends StandardSchemaV1> extends WatchableSource {
+  /**
+   * Connect to the standalone dev server for hot reload. On Vite, prefer
+   * `watchWithVite()` from `@fumadocs/local-content/dev/vite`.
+   */
+  devServer: (url?: string) => Promise<void>;
+  staticSource: (options?: SourceOptions) => Promise<
+    StaticSource<{
+      pageData: LocalHtmlPage;
+      metaData: StandardSchemaV1.InferOutput<MetaSchema> & MetaData;
+    }>
+  >;
+  dynamicSource: (options?: SourceOptions) => DynamicSource<{
+    pageData: LocalHtmlPage;
+    metaData: StandardSchemaV1.InferOutput<MetaSchema> & MetaData;
+  }>;
+
+  invalidateFile: (file: string) => void;
+}
+
+export type LocalHtmlPage = HtmlPage<HtmlRenderer>;
+
+export function localHtml<MetaSchema extends StandardSchemaV1 = typeof defaultSchemas.metaSchema>(
+  config: LocalHtmlConfig<MetaSchema>,
+): LocalHtml<MetaSchema> {
+  const source = createLocalSource({
+    dir: config.dir,
+    include: config.include,
+    integration: htmlIntegration({
+      include: config.include,
+      metaSchema: config.metaSchema,
+      async load(page) {
+        const res = processHtml(page.tree, config);
+
+        return fromAst({
+          tree: res.tree,
+          filePath: page.absolutePath,
+          rehypeToc: res.toc,
+          structuredData: res.structuredData,
+        });
+      },
+    }),
+  });
+
+  return source as unknown as LocalHtml<MetaSchema>;
+}
+
+export type { RawHtmlPage, HtmlPage } from './integration';
+export { htmlIntegration, defaultInclude } from './integration';
+export {
+  processHtml,
+  parseHtml,
+  type ProcessHtmlOptions,
+  type ProcessedHtml,
+} from './html/compiler';
+export type { HtmlRenderer, HtmlRendererOptions, HtmlRendererResult } from './html/renderer';
+export { fromAst } from './html/renderer';

--- a/packages/local-html/src/integration.ts
+++ b/packages/local-html/src/integration.ts
@@ -46,7 +46,10 @@ function extractMetadata(tree: Root): { title?: string; metadata: Record<string,
 
   visit(tree, 'element', (element: Element) => {
     if (element.tagName === 'title') {
-      title ??= textOf(element).trim();
+      if (!title) {
+        const text = textOf(element).trim();
+        if (text.length > 0) title = text;
+      }
       return 'skip';
     }
 
@@ -85,8 +88,8 @@ export function htmlIntegration<
 
     return {
       title:
-        metadata['fumadocs:title'] ?? title ?? path.basename(file.path, path.extname(file.path)),
-      description: metadata['fumadocs:description'] ?? metadata.description,
+        metadata['fumadocs:title'] || title || path.basename(file.path, path.extname(file.path)),
+      description: metadata['fumadocs:description'] || metadata.description,
       icon: metadata['fumadocs:icon'],
 
       metadata,
@@ -96,7 +99,14 @@ export function htmlIntegration<
   }
 
   async function meta(file: SourceFile): Promise<$Meta> {
-    const result = await metaSchema['~standard'].validate(JSON.parse(await file.read()));
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await file.read());
+    } catch (error) {
+      throw new Error(`invalid JSON in "${file.absolutePath}": ${String(error)}`);
+    }
+
+    const result = await metaSchema['~standard'].validate(parsed);
     if (result.issues) {
       throw new Error(`invalid data in "${file.absolutePath}": ${formatIssues(result.issues)}`);
     }

--- a/packages/local-html/src/integration.ts
+++ b/packages/local-html/src/integration.ts
@@ -1,0 +1,118 @@
+import path from 'node:path';
+import type { MetaData, PageData } from 'fumadocs-core/source';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import * as defaultSchemas from 'fumadocs-core/source/schema';
+import type { ContentIntegration, SourceFile } from '@fumadocs/local-content';
+import type { Element, Root } from 'hast';
+import { visit } from 'unist-util-visit';
+import { parseHtml, textOf } from './html/compiler';
+
+export const defaultInclude = ['**/*.{html,json}'];
+
+export interface RawHtmlPage {
+  path: string;
+  absolutePath: string;
+  /** the parsed document, including `<head>` when present */
+  tree: Root;
+  /** every `<meta name>`/`content` pair of the document */
+  metadata: Record<string, string>;
+}
+
+export interface HtmlPage<Loaded = unknown> extends PageData {
+  title: string;
+  description?: string;
+  icon?: string;
+  metadata: Record<string, string>;
+  tree: Root;
+  load: () => Promise<Loaded>;
+}
+
+export interface HtmlIntegrationConfig<MetaSchema extends StandardSchemaV1, Loaded> {
+  include?: string[];
+  metaSchema?: MetaSchema;
+  /** called at most once per page, until the file is invalidated */
+  load: (page: RawHtmlPage) => Promise<Loaded>;
+}
+
+function formatIssues(issues: readonly StandardSchemaV1.Issue[]): string {
+  return issues
+    .map((issue) => (issue.path ? `${issue.path}: ${issue.message}` : issue.message))
+    .join('\n');
+}
+
+function extractMetadata(tree: Root): { title?: string; metadata: Record<string, string> } {
+  const metadata: Record<string, string> = {};
+  let title: string | undefined;
+
+  visit(tree, 'element', (element: Element) => {
+    if (element.tagName === 'title') {
+      title ??= textOf(element).trim();
+      return 'skip';
+    }
+
+    if (element.tagName === 'meta') {
+      const { name, content } = element.properties;
+      if (typeof name === 'string' && typeof content === 'string') metadata[name] = content;
+    }
+  });
+
+  return { title, metadata };
+}
+
+/** reads `.html` files as pages and `.json` as meta, validated with Standard Schema */
+export function htmlIntegration<
+  MetaSchema extends StandardSchemaV1 = typeof defaultSchemas.metaSchema,
+  Loaded = unknown,
+>(
+  config: HtmlIntegrationConfig<MetaSchema, Loaded>,
+): ContentIntegration<HtmlPage<Loaded>, StandardSchemaV1.InferOutput<MetaSchema> & MetaData> {
+  const { include = defaultInclude, metaSchema = defaultSchemas.metaSchema, load } = config;
+
+  type $Meta = StandardSchemaV1.InferOutput<MetaSchema> & MetaData;
+
+  async function page(file: SourceFile): Promise<HtmlPage<Loaded>> {
+    const tree = parseHtml(await file.read());
+    const { title, metadata } = extractMetadata(tree);
+
+    const raw: RawHtmlPage = {
+      path: file.path,
+      absolutePath: file.absolutePath,
+      tree,
+      metadata,
+    };
+    // the parsed file is cached until invalidated, so this compiles once
+    let loaded: Promise<Loaded> | undefined;
+
+    return {
+      title:
+        metadata['fumadocs:title'] ?? title ?? path.basename(file.path, path.extname(file.path)),
+      description: metadata['fumadocs:description'] ?? metadata.description,
+      icon: metadata['fumadocs:icon'],
+
+      metadata,
+      tree,
+      load: () => (loaded ??= load(raw)),
+    };
+  }
+
+  async function meta(file: SourceFile): Promise<$Meta> {
+    const result = await metaSchema['~standard'].validate(JSON.parse(await file.read()));
+    if (result.issues) {
+      throw new Error(`invalid data in "${file.absolutePath}": ${formatIssues(result.issues)}`);
+    }
+
+    return result.value as $Meta;
+  }
+
+  return {
+    include,
+    async parse(file) {
+      switch (path.extname(file.path)) {
+        case '.json':
+          return { type: 'meta', data: await meta(file) };
+        case '.html':
+          return { type: 'page', data: await page(file) };
+      }
+    },
+  };
+}

--- a/packages/local-html/test/fixtures/deliverable.html
+++ b/packages/local-html/test/fixtures/deliverable.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Product Kickoff</title>
+    <meta name="description" content="Kickoff deck for the product team." />
+    <meta name="author" content="Docs Team" />
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      .statline {
+        display: flex;
+      }
+    </style>
+  </head>
+  <body onload="init()">
+    <header class="shell">
+      <span class="wordmark">Acme</span>
+      <nav><a href="#roadmap">Roadmap</a></nav>
+    </header>
+    <main class="content">
+      <h1 class="display">Product Kickoff</h1>
+      <p class="lede">What we are building and why it matters.</p>
+      <h2 id="goals">Goals</h2>
+      <p>Ship the first slice by <strong>March</strong>.</p>
+      <ul>
+        <li>Validate demand</li>
+        <li onclick="track()">Deliver the aha-moment</li>
+      </ul>
+      <h2>The Roadmap</h2>
+      <table class="evidence">
+        <thead>
+          <tr>
+            <th>Phase</th>
+            <th class="num">Weeks</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Now</td>
+            <td class="num" style="text-align: right">4</td>
+          </tr>
+          <tr>
+            <td>Next</td>
+            <td class="num">6</td>
+          </tr>
+        </tbody>
+      </table>
+      <script>
+        console.log('inline analytics');
+      </script>
+    </main>
+    <footer class="shell">Acme</footer>
+  </body>
+</html>

--- a/packages/local-html/test/fixtures/deliverable.renderer.json
+++ b/packages/local-html/test/fixtures/deliverable.renderer.json
@@ -1,0 +1,78 @@
+{
+  "structuredData": {
+    "headings": [
+      {
+        "id": "product-kickoff",
+        "content": "Product Kickoff"
+      },
+      {
+        "id": "goals",
+        "content": "Goals"
+      },
+      {
+        "id": "the-roadmap",
+        "content": "The Roadmap"
+      }
+    ],
+    "contents": [
+      {
+        "heading": "product-kickoff",
+        "content": "What we are building and why it matters."
+      },
+      {
+        "heading": "goals",
+        "content": "Ship the first slice by March."
+      },
+      {
+        "heading": "goals",
+        "content": "Validate demand"
+      },
+      {
+        "heading": "goals",
+        "content": "Deliver the aha-moment"
+      },
+      {
+        "heading": "the-roadmap",
+        "content": "Phase"
+      },
+      {
+        "heading": "the-roadmap",
+        "content": "Weeks"
+      },
+      {
+        "heading": "the-roadmap",
+        "content": "Now"
+      },
+      {
+        "heading": "the-roadmap",
+        "content": "4"
+      },
+      {
+        "heading": "the-roadmap",
+        "content": "Next"
+      },
+      {
+        "heading": "the-roadmap",
+        "content": "6"
+      }
+    ]
+  },
+  "bodyHtml": "\n      <h1 id=\"product-kickoff\">Product Kickoff</h1>\n      <p>What we are building and why it matters.</p>\n      <h2 id=\"goals\">Goals</h2>\n      <p>Ship the first slice by <strong>March</strong>.</p>\n      <ul>\n        <li>Validate demand</li>\n        <li>Deliver the aha-moment</li>\n      </ul>\n      <h2 id=\"the-roadmap\">The Roadmap</h2>\n      <table><thead><tr><th>Phase</th><th>Weeks</th></tr></thead><tbody><tr><td>Now</td><td>4</td></tr><tr><td>Next</td><td>6</td></tr></tbody></table>\n      \n    ",
+  "toc": [
+    {
+      "url": "#product-kickoff",
+      "depth": 1,
+      "titleHtml": "Product Kickoff"
+    },
+    {
+      "url": "#goals",
+      "depth": 2,
+      "titleHtml": "Goals"
+    },
+    {
+      "url": "#the-roadmap",
+      "depth": 2,
+      "titleHtml": "The Roadmap"
+    }
+  ]
+}

--- a/packages/local-html/test/fixtures/fragment.html
+++ b/packages/local-html/test/fixtures/fragment.html
@@ -1,0 +1,6 @@
+<meta name="fumadocs:title" content="A Fragment Page" />
+<meta name="fumadocs:description" content="Content without a document shell." />
+<h2>First Section</h2>
+<p>Some readable text.</p>
+<h3>Nested</h3>
+<blockquote>A quoted insight.</blockquote>

--- a/packages/local-html/test/fixtures/fragment.renderer.json
+++ b/packages/local-html/test/fixtures/fragment.renderer.json
@@ -1,0 +1,37 @@
+{
+  "structuredData": {
+    "headings": [
+      {
+        "id": "first-section",
+        "content": "First Section"
+      },
+      {
+        "id": "nested",
+        "content": "Nested"
+      }
+    ],
+    "contents": [
+      {
+        "heading": "first-section",
+        "content": "Some readable text."
+      },
+      {
+        "heading": "nested",
+        "content": "A quoted insight."
+      }
+    ]
+  },
+  "bodyHtml": "\n\n<h2 id=\"first-section\">First Section</h2>\n<p>Some readable text.</p>\n<h3 id=\"nested\">Nested</h3>\n<blockquote>A quoted insight.</blockquote>\n",
+  "toc": [
+    {
+      "url": "#first-section",
+      "depth": 2,
+      "titleHtml": "First Section"
+    },
+    {
+      "url": "#nested",
+      "depth": 3,
+      "titleHtml": "Nested"
+    }
+  ]
+}

--- a/packages/local-html/test/index.test.tsx
+++ b/packages/local-html/test/index.test.tsx
@@ -1,0 +1,134 @@
+import { expect, test } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { TOCItemType } from 'fumadocs-core/toc';
+import { localHtml, parseHtml, processHtml, fromAst } from '@/index';
+
+const cwd = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(cwd, 'fixtures');
+
+async function readFixture(name: string) {
+  const filePath = path.join(fixturesDir, name);
+  const content = await fs.readFile(filePath, 'utf8');
+  return { filePath, content };
+}
+
+function serializeToc(toc: TOCItemType[] | undefined) {
+  if (!toc?.length) return [];
+  return toc.map((item) => ({
+    url: item.url,
+    depth: item.depth,
+    titleHtml: renderToStaticMarkup(item.title),
+  }));
+}
+
+const cases = [
+  { name: 'deliverable', file: 'deliverable.html' },
+  { name: 'fragment', file: 'fragment.html' },
+] as const;
+
+for (const { name, file } of cases) {
+  test(`renderer: ${name}`, async () => {
+    const { filePath, content } = await readFixture(file);
+    const res = processHtml(parseHtml(content));
+    const renderer = fromAst({
+      tree: res.tree,
+      filePath,
+      rehypeToc: res.toc,
+      structuredData: res.structuredData,
+    });
+    const { body, toc } = await renderer.render();
+    const payload = {
+      structuredData: renderer.structuredData,
+      bodyHtml: renderToStaticMarkup(body),
+      toc: serializeToc(toc),
+    };
+
+    await expect(JSON.stringify(payload, null, 2)).toMatchFileSnapshot(
+      path.join(fixturesDir, `${name}.renderer.json`),
+    );
+  });
+}
+
+test('a full document adapts to the docs theme', async () => {
+  const { filePath, content } = await readFixture('deliverable.html');
+  const res = processHtml(parseHtml(content));
+  const renderer = fromAst({ tree: res.tree, filePath, rehypeToc: res.toc });
+  const html = renderToStaticMarkup((await renderer.render()).body);
+
+  // content scoped to <main>, chrome and non-content tags dropped
+  expect(html).not.toContain('wordmark');
+  expect(html).not.toContain('<script');
+  expect(html).not.toContain('<style');
+  // styling hooks removed so prose styles take over
+  expect(html).not.toContain('class=');
+  expect(html).not.toContain('style=');
+  expect(html).not.toContain('onclick');
+  // content survives
+  expect(html).toContain('<strong>March</strong>');
+  expect(html).toContain('<table>');
+});
+
+test('headings get generated ids and drive toc + structured data', async () => {
+  const { content } = await readFixture('deliverable.html');
+  const res = processHtml(parseHtml(content));
+
+  expect(res.toc.map((item) => item.url)).toEqual(['#product-kickoff', '#goals', '#the-roadmap']);
+  expect(res.structuredData.headings).toContainEqual({
+    id: 'the-roadmap',
+    content: 'The Roadmap',
+  });
+  expect(res.structuredData.contents).toContainEqual({
+    heading: 'goals',
+    content: 'Validate demand',
+  });
+});
+
+test('components map onto html tags', async () => {
+  const { filePath, content } = await readFixture('fragment.html');
+  const res = processHtml(parseHtml(content));
+  const renderer = fromAst({ tree: res.tree, filePath, rehypeToc: res.toc });
+  const { body } = await renderer.render({
+    h2: (props) => <h2 {...props} data-custom="true" />,
+  });
+
+  expect(renderToStaticMarkup(body)).toContain('data-custom="true"');
+});
+
+test('source: metadata comes from the document head', async () => {
+  const source = await localHtml({ dir: fixturesDir }).staticSource();
+  const pages = source.files.filter((file) => file.type === 'page');
+  const byPath = Object.fromEntries(pages.map((page) => [page.path, page]));
+
+  const deliverable = byPath['deliverable.html'];
+  if (deliverable?.type !== 'page') throw new Error('expected a page');
+  expect(deliverable.data.title).toBe('Product Kickoff');
+  expect(deliverable.data.description).toBe('Kickoff deck for the product team.');
+  expect(deliverable.data.metadata.author).toBe('Docs Team');
+
+  const fragment = byPath['fragment.html'];
+  if (fragment?.type !== 'page') throw new Error('expected a page');
+  expect(fragment.data.title).toBe('A Fragment Page');
+  expect(fragment.data.description).toBe('Content without a document shell.');
+});
+
+test('load() compiles each page only once', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'local-html-cache-'));
+
+  try {
+    await fs.writeFile(path.join(dir, 'a.html'), '<h1>A</h1><p>text</p>');
+
+    const source = await localHtml({ dir }).staticSource();
+    const page = source.files.find((file) => file.type === 'page');
+    if (page?.type !== 'page') throw new Error('expected a page');
+
+    const first = await page.data.load();
+    const second = await page.data.load();
+    expect(first).toBe(second);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/local-html/test/index.test.tsx
+++ b/packages/local-html/test/index.test.tsx
@@ -98,6 +98,52 @@ test('components map onto html tags', async () => {
   expect(renderToStaticMarkup(body)).toContain('data-custom="true"');
 });
 
+test('embedding elements are dropped', async () => {
+  const res = processHtml(
+    parseHtml(
+      '<p>safe</p><iframe src="https://evil.example"></iframe><object data="x"></object><embed src="y">',
+    ),
+  );
+  const html = renderToStaticMarkup((await fromAst({ tree: res.tree }).render()).body);
+
+  expect(html).toContain('safe');
+  expect(html).not.toContain('<iframe');
+  expect(html).not.toContain('<object');
+  expect(html).not.toContain('<embed');
+});
+
+test('processHtml does not mutate the input tree', () => {
+  const input = parseHtml('<h1 class="big">Title</h1><script>evil()</script>');
+  const before = JSON.stringify(input);
+  processHtml(input);
+
+  expect(JSON.stringify(input)).toBe(before);
+});
+
+test('generated slugs avoid pre-existing heading ids', () => {
+  const res = processHtml(parseHtml('<h2>Setup</h2><h2 id="setup">Other</h2>'));
+
+  expect(res.toc.map((item) => item.url)).toEqual(['#setup-1', '#setup']);
+});
+
+test('an empty <title> falls back to the file name', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'local-html-title-'));
+
+  try {
+    await fs.writeFile(
+      path.join(dir, 'untitled.html'),
+      '<!doctype html><html><head><title>  </title></head><body><p>x</p></body></html>',
+    );
+
+    const source = await localHtml({ dir }).staticSource();
+    const page = source.files.find((file) => file.type === 'page');
+    if (page?.type !== 'page') throw new Error('expected a page');
+    expect(page.data.title).toBe('untitled');
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('source: metadata comes from the document head', async () => {
   const source = await localHtml({ dir: fixturesDir }).staticSource();
   const pages = source.files.filter((file) => file.type === 'page');

--- a/packages/local-html/test/index.test.tsx
+++ b/packages/local-html/test/index.test.tsx
@@ -112,6 +112,20 @@ test('embedding elements are dropped', async () => {
   expect(html).not.toContain('<embed');
 });
 
+test('the body fallback drops page chrome', async () => {
+  const res = processHtml(
+    parseHtml(
+      '<!doctype html><html><body><header>chrome</header><nav>links</nav><p>content</p><footer>chrome</footer></body></html>',
+    ),
+  );
+  const html = renderToStaticMarkup((await fromAst({ tree: res.tree }).render()).body);
+
+  expect(html).toContain('content');
+  expect(html).not.toContain('<header');
+  expect(html).not.toContain('<nav');
+  expect(html).not.toContain('<footer');
+});
+
 test('processHtml does not mutate the input tree', () => {
   const input = parseHtml('<h1 class="big">Title</h1><script>evil()</script>');
   const before = JSON.stringify(input);

--- a/packages/local-html/tsconfig.json
+++ b/packages/local-html/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM"],
+    "module": "ESNext",
+    "target": "ES2020"
+  },
+  "exclude": ["node_modules", "eslint.config.mjs", "dist"]
+}

--- a/packages/local-html/tsdown.config.ts
+++ b/packages/local-html/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  dts: true,
+  fixedExtension: false,
+  target: 'es2023',
+  entry: ['./src/{index,client}.ts'],
+  format: 'esm',
+  deps: {
+    onlyBundle: [],
+    neverBundle: [],
+  },
+});

--- a/packages/local-html/vitest.config.ts
+++ b/packages/local-html/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+  resolve: {
+    alias: {
+      '@/': new URL('./src/', import.meta.url).pathname,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2775,6 +2775,61 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  packages/local-html:
+    dependencies:
+      '@fumadocs/local-content':
+        specifier: workspace:*
+        version: link:../local-content
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
+      hast-util-from-html:
+        specifier: ^2.0.3
+        version: 2.0.3
+      hast-util-to-jsx-runtime:
+        specifier: ^2.3.6
+        version: 2.3.6
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+    devDependencies:
+      '@types/hast':
+        specifier: ^3.0.5
+        version: 3.0.5
+      '@types/node':
+        specifier: 26.2.0
+        version: 26.2.0
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.18)
+      fumadocs-core:
+        specifier: workspace:*
+        version: link:../core
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+      tsdown:
+        specifier: 0.22.14
+        version: 0.22.14(@tsdown/css@0.22.14)(oxc-resolver@11.19.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.3.1)
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+
   packages/local-md:
     dependencies:
       '@fumadocs/local-content':


### PR DESCRIPTION
## Summary

Adds `@fumadocs/local-html`, a content source for local HTML files. It integrates externally-produced HTML pages (exported decks, reports, agent-generated deliverables, output of other tools) into a Fumadocs site, **adapting them to the docs theme** rather than embedding them as-is.

For each `.html` file it:

- scopes the content to `<main>`/`<article>` (falling back to `<body>`), dropping page chrome (`<header>`/`<footer>`/`<nav>`), `<script>` and `<style>` tags;
- removes `class`/`style` attributes by default so the docs prose styling takes over (`adaptStyles: false` opts out; inline event handlers are always stripped);
- generates heading ids (`github-slugger`) and builds the TOC with the existing hast-based `rehypeToc` from `fumadocs-core`;
- produces `structuredData` from headings and text blocks, so HTML pages are search-indexed like Markdown pages;
- reads title/description from `<title>`/`<meta>` (overridable via `fumadocs:title`, `fumadocs:description`, `fumadocs:icon` metas);
- renders through `hast-util-to-jsx-runtime`, so tags can be mapped to the site's components at render phase.

The package mirrors the `@fumadocs/local-md` + `@fumadocs/local-content` architecture: same integration/source split, same `staticSource()`/`dynamicSource()` API, same renderer shape (`load()` → `render(components)` → `{ body, toc }`), and it reuses `@fumadocs/local-content` for scanning/caching/watching, so the existing Vite/dev-server watchers work unchanged.

Included:

- `packages/local-html` — source, tests (fixtures + snapshots), README
- docs page: `apps/docs/content/docs/(framework)/integrations/content/local-html.mdx`
- tegami changelog entry, `.oxfmtrc.jsonc` snapshot-ignore entry (same pattern as `local-md`)

## Related Issues

Closes #3474

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Additional Context

Local verification: `oxfmt --check` clean, `turbo lint` 34/34, `types:check` 61/61, full `vitest` suite 498 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `@fumadocs/local-html` integration for importing externally generated HTML into documentation.
  - Supports full documents and fragments, metadata, JSON content, configurable components, search indexing, and static or dynamic sources.
  - Automatically scopes content, removes page chrome and unsafe styling/scripts, and generates heading IDs and tables of contents.

- **Documentation**
  - Added setup guides, usage examples, configuration details, limitations, and rendering documentation.

- **Tests**
  - Added coverage for parsing, rendering, metadata, component mapping, and caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->