### PR TITLE
fix(docs): remove nested <main> on the home page

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -67,7 +67,7 @@ const cardVariants = cva('rounded-2xl text-sm p-6 bg-origin-border shadow-lg', {
 
 export default function Page() {
   return (
-    <main className="text-landing-foreground pt-4 pb-6 dark:text-landing-foreground-dark md:pb-12">
+    <div className="text-landing-foreground pt-4 pb-6 dark:text-landing-foreground-dark md:pb-12">
       <div className="relative flex min-h-[600px] h-[70vh] max-h-[900px] border rounded-2xl overflow-hidden mx-auto w-full max-w-[1400px] bg-origin-border">
         <Hero />
         <div className="flex flex-col z-2 px-4 size-full md:p-12 max-md:items-center max-md:text-center">
@@ -143,7 +143,7 @@ export default function Page() {
         <ForNonEnginners />
         <OpenSource />
       </div>
-    </main>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

`apps/docs/app/(home)/page.tsx` wraps its content in `<main>`, but `HomeLayout` already renders the
page's `<main id="nd-home-layout">`
(`packages/base-ui/src/layouts/home/slots/container.tsx`). The live site therefore ships two:

```js
// https://www.fumadocs.dev/
document.querySelectorAll('main').length; // 2  →  main#nd-home-layout, main
```

Per the HTML standard every `main` must be [hierarchically
correct](https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element) — ancestors
limited to `html`, `body`, `div`, `form` without an accessible name, and autonomous custom
elements — so a `main` inside a `main` is invalid, and only one visible `main` is expected per
document. Two main landmarks also leave assistive technology with no way to tell which is the
document's.

This changes the wrapper to a `div`, which is what every example already does: all 14
`examples/*/app/(home)/page.tsx` use a `div`, and searching `<main` under `examples/` returns no
hits. No visual change — both are `display: block` and the classes are untouched.

Worth fixing beyond validity, because the marketing page is what people read when they build their
own: this is how the nested `main` reached at least one downstream site.

No `tegami` entry, as no published package changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] Verified on the live site rather than only in source
