### PR TITLE
docs: update Sora UI showcase URL

### DIFF
--- a/apps/docs/app/(home)/showcase/page.tsx
+++ b/apps/docs/app/(home)/showcase/page.tsx
@@ -156,7 +156,7 @@ const showcases: ShowcaseObject[] = [
   {
     image: '/showcases/sora-ui.png',
     name: 'Sora UI',
-    url: 'https://ui.soralabs.io.vn',
+    url: 'https://ui.soralabs.studio',
   },
   {
     image: '/showcases/kibo-ui.jpg',


### PR DESCRIPTION
## Summary
- Updates the [Sora UI](https://ui.soralabs.studio) showcase link from `https://ui.soralabs.io.vn` to `https://ui.soralabs.studio` after the site moved.

## Test plan
- [ ] Open `/showcase` and confirm the Sora UI card links to https://ui.soralabs.studio
- [ ] Confirm the destination site loads (Sora UI has moved from the old `.io.vn` domain)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Sora UI showcase link to the correct website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->