### PR TITLE
test(core): cover shiki highlighting of code blocks nested in list items

### DIFF
--- a/packages/core/test/rehype-code.test.ts
+++ b/packages/core/test/rehype-code.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+import { remark } from 'remark';
+import remarkRehype from 'remark-rehype';
+import { visit } from 'unist-util-visit';
+import type { Element, Root } from 'hast';
+import { rehypeCode } from '@/mdx-plugins';
+
+async function process(source: string): Promise<Root> {
+  const processor = remark().use(remarkRehype).use(rehypeCode, { inline: 'tailing-curly-colon' });
+
+  return (await processor.run(processor.parse(source))) as Root;
+}
+
+/**
+ * Shiki emits `<span style="--shiki-light:...">` token elements, raw text
+ * doesn't. Counting them tells us whether the node was highlighted.
+ */
+function countTokens(tree: Root, tagName: 'pre' | 'code'): number {
+  let count = 0;
+
+  visit(tree, 'element', (node: Element) => {
+    if (node.tagName !== tagName) return;
+    const classes = node.properties?.class ?? node.properties?.className;
+    if (!String(classes ?? '').includes('shiki')) return;
+
+    visit(node, 'element', (child: Element) => {
+      if (child.tagName === 'span' && typeof child.properties?.style === 'string') count++;
+    });
+  });
+
+  return count;
+}
+
+describe('Rehype Code', () => {
+  test('highlights a top-level code block', async () => {
+    const tree = await process(['```ts', 'console.log("hello");', '```'].join('\n'));
+
+    expect(countTokens(tree, 'pre')).toBeGreaterThan(0);
+  });
+
+  // the visitor used to `return 'skip'` on every unmatched element, which
+  // aborted traversal of the entire subtree of the first wrapper element.
+  test.each([
+    ['list item', ['1. item', '', '   ```ts', '   console.log("hello");', '   ```'].join('\n')],
+    ['blockquote', ['> ```ts', '> console.log("hello");', '> ```'].join('\n')],
+  ])('highlights a code block nested inside a %s', async (_name, source) => {
+    const tree = await process(source);
+
+    expect(countTokens(tree, 'pre')).toBeGreaterThan(0);
+  });
+
+  test('highlights inline code nested inside a list item', async () => {
+    const tree = await process('1. item `console.log("hello"){:ts}`');
+
+    expect(countTokens(tree, 'code')).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a regression test for `rehypeCode` covering syntax highlighting of code blocks nested inside wrapper elements.

Until `9cf33e9b1` ("Twoslash: Support lazy loading with `rehype-code`"), the `rehypeShikiFromHighlighter` visitor returned `'skip'` for every element it did not match, which stopped `unist-util-visit` from descending into the subtree. The first `<ol>`, `<ul>`, `<li>`, `<blockquote>` or `<td>` therefore aborted traversal of everything below it, so a fence inside a list item was never handed to shiki and rendered as raw text. The same line disabled the inline `{:lang}` parser below any wrapper element.

That commit fixed it by adding an `else { return; }` branch, and the fix shipped in `fumadocs-core@16.7.16`. Nothing guarded the behaviour afterwards, so this PR adds the missing test — there is no source change here.

`packages/core/test/rehype-code.test.ts` runs `remark().use(remarkRehype).use(rehypeCode, { inline: 'tailing-curly-colon' })` and counts shiki token spans (`<span style="--shiki-light:…">`) under a `.shiki` node, for four cases:

- a top-level fence (control)
- a fence inside a list item
- a fence inside a blockquote
- inline `` `code{:ts}` `` inside a list item

Verified as a real guard rather than a test that passes regardless: deleting the `else { return; }` branch from `packages/core/src/mdx-plugins/rehype-code/shiki.ts` fails the three nested cases and leaves the top-level case passing, which is exactly the original failure mode. The branch was restored afterwards.

No changeset — the change is test-only and does not affect any published package.

## Related Issues

None.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): test-only, regression coverage for an already-fixed bug

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Additional Context

`packages/core/test/mdx-plugins.test.ts` has three pre-existing `Remark Image` failures on `dev` that are unrelated to this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for syntax highlighting of code blocks and inline code.
  * Verified highlighting works for code nested in lists and blockquotes.
  * Added regression checks for nested content traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->