### PR TITLE
fix(api-docs): intersect overlapping type sets when merging allOf

### DIFF
--- a/.tegami/2026-09-01-merge-allof-type-intersection.md
+++ b/.tegami/2026-09-01-merge-allof-type-intersection.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@fumadocs/api-docs: patch
+---
+
+## Keep overlapping `type` sets when merging `allOf`
+
+`intersection` treated any difference in the `type` keyword as an impossible schema and returned `false`, so an `allOf` member using a type array (e.g. `['string', 'null']`, emitted for `nullable: true`) merged with a typed member (`type: 'string'`) produced `false` instead of `type: 'string'` — dropping every property of the schema in the Schema UI and the playground.
+
+Intersecting overlapping type sets now keeps the shared members, and only genuinely disjoint types (e.g. `['string']` with `['number']`) resolve to `false`.

--- a/packages/api-docs/src/schema/merge.ts
+++ b/packages/api-docs/src/schema/merge.ts
@@ -118,13 +118,30 @@ function intersection(a: ParsedSchema, b: ParsedSchema): ParsedSchema {
       }
       // require same
       case 'format':
-      case 'const':
-      case 'type': {
+      case 'const': {
         const value = b[key];
         if (value === undefined) break;
         result[key] ??= value;
 
         if (!deepEqual(result[key], value)) return false;
+        break;
+      }
+      case 'type': {
+        const value = b[key];
+        if (value === undefined) break;
+        if (result[key] === undefined) {
+          result[key] = value;
+          break;
+        }
+
+        // `type` can be a scalar or an array (e.g. `nullable: true` becomes ['string', 'null'])
+        // intersect both sets, only genuinely disjoint types are impossible
+        const aTypes = Array.isArray(result[key]) ? result[key] : [result[key]];
+        const bTypes = Array.isArray(value) ? value : [value];
+        const shared = aTypes.filter((t) => bTypes.includes(t));
+        if (shared.length === 0) return false;
+
+        result[key] = shared.length === 1 ? shared[0] : shared;
         break;
       }
       // add

--- a/packages/api-docs/test/utils.test.ts
+++ b/packages/api-docs/test/utils.test.ts
@@ -383,6 +383,29 @@ describe('Merge object schemas', () => {
       }
     `);
   });
+
+  test('Intersect overlapping `type` sets instead of returning `false`', () => {
+    // a nullable member (`type` array, from `nullable: true`) merged with a typed member
+    expect(
+      mergeAllOf({
+        allOf: [{ type: ['string', 'null'] }, { type: 'string' }],
+      }),
+    ).toEqual({ type: 'string' });
+
+    // two overlapping type arrays keep the shared member
+    expect(
+      mergeAllOf({
+        allOf: [{ type: ['string', 'null'] }, { type: ['string', 'number'] }],
+      }),
+    ).toEqual({ type: 'string' });
+
+    // disjoint type sets are genuinely impossible
+    expect(
+      mergeAllOf({
+        allOf: [{ type: ['string'] }, { type: ['number'] }],
+      }),
+    ).toEqual(false);
+  });
 });
 
 describe('URL utilities', () => {


### PR DESCRIPTION
## Summary

`mergeAllOf` treated any difference in the `type` keyword as an impossible schema and returned `false`, so an `allOf` member using a type array (e.g. `['string', 'null']`, emitted when `nullable: true`) merged with a typed member (`type: 'string'`) produced `false` instead of `type: 'string'`, and that `false` propagates into the Schema UI (renders a `never` primitive, dropping every property of the object) and into the playground (`useResolvedSchema` replaces it with an `any` field)

`intersection` now intersects the two type sets (scalar and array forms), keeps the shared members, and returns `false` only when the intersection is genuinely empty (e.g. `['string']` with `['number']`)

reproduced pre-change:

```
mergeAllOf({ allOf: [{ type: ['string','null'] }, { type: 'string' }] }) -> false   // wrong
mergeAllOf({ allOf: [{ type: ['string','null'] }, { type: ['string','number'] }] }) -> false  // wrong
mergeAllOf({ allOf: [{ type: ['string'] }, { type: ['number'] }] }) -> false      // correct (impossible)
```

post-fix the first two resolve to `{ type: 'string' }`

## Related Issues

sibling fix in the same helper as #3084 (allOf with multiple oneOf arrays) and #3500 (allOf drops descriptions), no open issue tracked this exact case

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Additional Context

new test `Intersect overlapping type sets instead of returning false` with three cases, it fails without the change, `@fumadocs/api-docs` unit suite 41 tests and `fumadocs-openapi` suite 43 tests pass, oxlint 0 errors, tsc clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `allOf` schema merging so overlapping type definitions are preserved.
  - Compatible type values are now intersected correctly, including nullable and multi-type schemas.
  - Disjoint type definitions continue to be rejected.

- **Documentation**
  - Added a changeset documenting the updated type intersection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->