### PR TITLE
fix(api-docs): preserve outer allOf titles

### DIFF
--- a/.tegami/2026-09-02-mtk3ouiw.md
+++ b/.tegami/2026-09-02-mtk3ouiw.md
@@ -1,0 +1,8 @@
+---
+packages:
+  npm:@fumadocs/api-docs: patch
+---
+
+## Preserve outer titles when merging `allOf`
+
+An `allOf` schema's title now names the merged schema without being appended to nested union members. Untitled intersections still combine their member titles.

--- a/packages/api-docs/src/schema/merge.ts
+++ b/packages/api-docs/src/schema/merge.ts
@@ -9,13 +9,14 @@ export function mergeAllOf(schema: ParsedSchema): ParsedSchema {
   schema = dereferenceShallow(schema);
   if (typeof schema === 'boolean' || !schema.allOf) return schema;
 
-  const { allOf, ...rest } = schema;
+  const { allOf, title, ...rest } = schema;
   let result: ParsedSchema = rest;
   for (const item of allOf) {
     result = intersection(result, item);
   }
-  if (typeof result !== 'boolean' && rest.description !== undefined) {
-    result.description = rest.description;
+  if (typeof result !== 'boolean') {
+    if (rest.description !== undefined) result.description = rest.description;
+    if (title !== undefined) result.title = title;
   }
   return result;
 }

--- a/packages/api-docs/test/utils.test.ts
+++ b/packages/api-docs/test/utils.test.ts
@@ -248,6 +248,34 @@ describe('Merge object schemas', () => {
     ).toEqual({ description: 'Outer' });
   });
 
+  test('Merge multiple objects: outer `title`', () => {
+    expect(
+      mergeAllOf({
+        title: 'Payload',
+        allOf: [
+          { description: 'Event payload.' },
+          {
+            oneOf: [
+              {
+                title: 'Child',
+                allOf: [{ title: 'Base', type: 'object' }],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      title: 'Payload',
+      oneOf: [{ title: 'Child', type: 'object', description: 'Event payload.' }],
+    });
+
+    expect(
+      mergeAllOf({
+        allOf: [{ title: 'Readable' }, { title: 'Writable' }],
+      }),
+    ).toEqual({ title: 'Readable & Writable' });
+  });
+
   test('Production: `allOf` with multiple `oneOf`', () => {
     const result = mergeAllOf({
       type: 'object',


### PR DESCRIPTION
## Summary

- Preserve an explicit outer `title` when `mergeAllOf()` merges a schema.
- Keep that title out of nested `oneOf` and `anyOf` member titles.
- Preserve combined member titles for untitled intersections.

`mergeAllOf()` previously included the outer title in the intermediate intersection. When the schema also contained a union, intersection distribution appended that title to every union member. A schema titled `Payload` with a child titled `Child` could therefore render as `Child & Base & Payload`.

The merge now removes the outer title from the intermediate value and restores it after merging. This follows the existing precedence rule for the outer description without changing untitled intersection labels.

## Related issues

No related issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other

## Checklist

- [x] I have read the contributing guide.
- [x] My code follows the project style.
- [x] I have added tests.
- [x] I have tested my changes locally.
- [ ] I have linked a related issue.
- [ ] I have added screenshots. The regression is covered at the schema merge boundary.

## Verification

- `pnpm exec vitest run packages/api-docs/test`
- `pnpm --filter @fumadocs/api-docs... build`
- `tsc --noEmit -p packages/api-docs/tsconfig.json`
- `oxlint packages/api-docs/src/schema/merge.ts packages/api-docs/test/utils.test.ts`
- `oxfmt --check packages/api-docs/src/schema/merge.ts packages/api-docs/test/utils.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected schema title handling when merging `allOf` definitions.
  - Top-level titles now remain associated with the merged schema instead of being appended to nested union member titles.
  - Untitled intersections continue combining member titles as expected.

- **Tests**
  - Added coverage for title preservation and combined titles during schema merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->