### PR TITLE
refactor(create-app): replace ts-morph with oxc-parser

### DIFF
--- a/.tegami/2026-09-04-create-app-oxc.md
+++ b/.tegami/2026-09-04-create-app-oxc.md
@@ -1,0 +1,8 @@
+---
+packages:
+  npm:create-fumadocs-app: patch
+---
+
+## Replace ts-morph with oxc-parser
+
+Template transforms (routes, prerender config, `RootProvider` search dialog, AI chat layout) now parse files with `oxc-parser` and edit the source text in place, instead of `ts-morph` and the TypeScript 6 compiler it bundles. Edits preserve the original formatting, including trailing commas.

--- a/examples/stackblitz/package.json
+++ b/examples/stackblitz/package.json
@@ -28,7 +28,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "tailwindcss": "^4.3.0",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vite": "^8.0.13"
   }
 }

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -46,9 +46,10 @@
     "@fumadocs/cli": "workspace:*",
     "commander": "^15.0.0",
     "fuma-cli": "^0.1.1",
+    "magic-string": "^1.2.3",
+    "oxc-parser": "^0.128.0",
     "picocolors": "^1.1.1",
-    "tinyexec": "^1.3.0",
-    "ts-morph": "^28.0.0"
+    "tinyexec": "^1.3.0"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",

--- a/packages/create-app/src/plugins/ai.ts
+++ b/packages/create-app/src/plugins/ai.ts
@@ -1,8 +1,12 @@
 import { TemplatePlugin, TemplatePluginContext } from '@/index';
-import { createSourceFile } from '@/transform/shared';
+import {
+  addImport,
+  createSourceFile,
+  findJsxElement,
+  prependJsxChildren,
+} from '@/transform/shared';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { SyntaxKind } from 'ts-morph';
 import { FumadocsComponentInstaller } from '@fumadocs/cli/registry/installer';
 import { HttpRegistryConnector } from 'fuma-cli/registry/connector';
 import { getDefaultConfig } from '@fumadocs/cli/config';
@@ -60,7 +64,6 @@ async function addAIChat({ template, appDir }: TemplatePluginContext) {
   }
 
   const file = await createSourceFile(filePath);
-  const elements = file.getDescendantsOfKind(SyntaxKind.JsxElement);
   const code = `<AISearch>
   <AISearchPanel />
   <AISearchTrigger
@@ -77,36 +80,16 @@ async function addAIChat({ template, appDir }: TemplatePluginContext) {
   </AISearchTrigger>
 </AISearch>`;
 
-  for (const element of elements) {
-    const opening = element.getFirstChildByKind(SyntaxKind.JsxOpeningElement);
-    if (opening?.getTagNameNode().getText() !== 'DocsLayout') continue;
+  const layout = findJsxElement(file, 'DocsLayout');
+  if (layout) prependJsxChildren(file, layout, code);
 
-    const prior = element
-      .getJsxChildren()
-      .map((child) => child.print().trim())
-      .join('\n');
-    element.setBodyText(`${code}\n\n${prior}`);
-    break;
-  }
-
-  file.addImportDeclarations([
-    {
-      moduleSpecifier: '@/components/ai/search',
-      namedImports: ['AISearch', 'AISearchPanel', 'AISearchTrigger'],
-    },
-    {
-      moduleSpecifier: 'lucide-react',
-      namedImports: ['MessageCircleIcon'],
-    },
-    {
-      moduleSpecifier: '@/lib/cn',
-      namedImports: ['cn'],
-    },
-    {
-      moduleSpecifier: 'fumadocs-ui/components/ui/button',
-      namedImports: ['buttonVariants'],
-    },
-  ]);
+  addImport(file, {
+    from: '@/components/ai/search',
+    named: ['AISearch', 'AISearchPanel', 'AISearchTrigger'],
+  });
+  addImport(file, { from: 'lucide-react', named: ['MessageCircleIcon'] });
+  addImport(file, { from: '@/lib/cn', named: ['cn'] });
+  addImport(file, { from: 'fumadocs-ui/components/ui/button', named: ['buttonVariants'] });
 
   await file.save();
 }

--- a/packages/create-app/src/transform/index.ts
+++ b/packages/create-app/src/transform/index.ts
@@ -1,5 +1,5 @@
 import { TemplatePluginContext } from '@/index';
-import { createSourceFile } from '@/transform/shared';
+import { addImport, addJsxAttribute, createSourceFile, findJsxElement } from '@/transform/shared';
 import path from 'node:path';
 import {
   addReactRouterRoute,
@@ -8,7 +8,6 @@ import {
 } from '@/transform/react-router';
 import fs from 'node:fs/promises';
 import { addTanstackPrerender } from '@/transform/tanstack-start';
-import { StructureKind, SyntaxKind } from 'ts-morph';
 
 interface RootLayoutMod {
   addSearchDialog: (specifier: string) => void;
@@ -21,34 +20,20 @@ export async function rootProvider(
   const file = await createSourceFile(path.join(appDir, template.rootProviderPath));
   fn({
     addSearchDialog(specifier) {
-      const elements = file.getDescendantsOfKind(SyntaxKind.JsxElement);
+      const provider = findJsxElement(file, 'RootProvider')?.openingElement;
+      if (!provider) return;
 
-      for (const element of elements) {
-        const provider = element.getFirstChildByKind(SyntaxKind.JsxOpeningElement);
-        if (provider?.getTagNameNode().getText() !== 'RootProvider') continue;
+      const { attributes } = provider;
+      const hasSearch = attributes.some(
+        (attr) =>
+          attr.type === 'JSXAttribute' &&
+          attr.name.type === 'JSXIdentifier' &&
+          attr.name.name === 'search',
+      );
+      if (hasSearch) return;
 
-        // Skip if search prop already exists
-        if (
-          provider
-            .getAttributes()
-            .some(
-              (attr) =>
-                attr.isKind(SyntaxKind.JsxAttribute) && attr.getNameNode().getText() === 'search',
-            )
-        )
-          continue;
-
-        provider.addAttribute({
-          kind: StructureKind.JsxAttribute,
-          name: 'search',
-          initializer: '{{ SearchDialog }}',
-        });
-        file.addImportDeclaration({
-          moduleSpecifier: specifier,
-          defaultImport: 'SearchDialog',
-        });
-        break;
-      }
+      addJsxAttribute(file, provider, 'search={{ SearchDialog }}');
+      addImport(file, { from: specifier, default: 'SearchDialog' });
     },
   });
   await file.save();

--- a/packages/create-app/src/transform/react-router.ts
+++ b/packages/create-app/src/transform/react-router.ts
@@ -3,8 +3,8 @@ import {
   addElements,
   filterElements,
   find,
-  findAll,
   getCodeValue,
+  getDefaultExport,
   getProperty,
   type SourceFile,
 } from '@/transform/shared';
@@ -20,7 +20,9 @@ export function filterReactRouterPrerenderArray(
   const method = getPrerenderMethod(file);
   if (!method) return;
 
-  const initializer = findAll(method.value, 'VariableDeclarator').find(
+  const initializer = find(
+    method.value,
+    'VariableDeclarator',
     (item) => item.id.type === 'Identifier' && item.id.name === array,
   )?.init;
   if (initializer?.type !== 'ArrayExpression') return;
@@ -64,13 +66,10 @@ export function filterReactRouterRoute(
   });
 }
 
-export function modifyReactRouterRoutes(file: SourceFile, mod: (array: ArrayExpression) => void) {
-  const initializer = getDefaultExport(file) && find(getDefaultExport(file)!, 'ArrayExpression');
+function modifyReactRouterRoutes(file: SourceFile, mod: (array: ArrayExpression) => void) {
+  const exported = getDefaultExport(file);
+  const initializer = exported && find(exported, 'ArrayExpression');
   if (initializer) mod(initializer);
-}
-
-function getDefaultExport(file: SourceFile) {
-  return file.program.body.find((node) => node.type === 'ExportDefaultDeclaration');
 }
 
 /**

--- a/packages/create-app/src/transform/react-router.ts
+++ b/packages/create-app/src/transform/react-router.ts
@@ -1,42 +1,45 @@
-import { ArrayLiteralExpression, MethodDeclaration, SourceFile, ts } from 'ts-morph';
-import { getCodeValue } from '@/transform/shared';
-import SyntaxKind = ts.SyntaxKind;
+import type { ArrayExpression, ObjectProperty } from 'oxc-parser';
+import {
+  addElements,
+  filterElements,
+  find,
+  findAll,
+  getCodeValue,
+  getProperty,
+  type SourceFile,
+} from '@/transform/shared';
 
 /**
  * filter items in a specific array initializer in the prerender function
  */
 export function filterReactRouterPrerenderArray(
-  sourceFile: SourceFile,
+  file: SourceFile,
   array: 'paths' | 'excluded',
   filter: (item: string) => boolean,
 ) {
-  const methodBody = getPrerenderMethod(sourceFile)?.getBody();
-  if (!methodBody) return;
+  const method = getPrerenderMethod(file);
+  if (!method) return;
 
-  const initializer = methodBody
-    .getDescendantsOfKind(SyntaxKind.VariableDeclaration)
-    .find((item) => item.getName() === array)
-    ?.getInitializerIfKind(SyntaxKind.ArrayLiteralExpression);
+  const initializer = findAll(method.value, 'VariableDeclarator').find(
+    (item) => item.id.type === 'Identifier' && item.id.name === array,
+  )?.init;
+  if (initializer?.type !== 'ArrayExpression') return;
 
-  if (!initializer) return;
-  for (const element of initializer.getElements()) {
-    if (!filter(getCodeValue(element.getText()))) {
-      initializer.removeElement(element);
-    }
-  }
+  filterElements(file, initializer, (element) =>
+    filter(getCodeValue(file.code.slice(element.start, element.end))),
+  );
 }
 
 /**
  * Add a new route to route config
  */
-export function addReactRouterRoute(
-  sourceFile: SourceFile,
-  routes: { path: string; entry: string }[],
-) {
-  modifyReactRouterRoutes(sourceFile, (arr) => {
-    for (const { path, entry } of routes) {
-      arr.addElement(`route('${path}', '${entry}')`);
-    }
+export function addReactRouterRoute(file: SourceFile, routes: { path: string; entry: string }[]) {
+  modifyReactRouterRoutes(file, (arr) => {
+    addElements(
+      file,
+      arr,
+      routes.map(({ path, entry }) => `route('${path}', '${entry}')`),
+    );
   });
 }
 
@@ -44,52 +47,38 @@ export function addReactRouterRoute(
  * Remove routes from route config (root level only)
  */
 export function filterReactRouterRoute(
-  sourceFile: SourceFile,
+  file: SourceFile,
   filter: (item: { path: string; entry: string }) => boolean,
 ) {
-  modifyReactRouterRoutes(sourceFile, (arr) => {
-    for (const element of arr.getElements()) {
-      if (
-        !element.isKind(SyntaxKind.CallExpression) ||
-        element.getFirstChildByKind(SyntaxKind.Identifier)?.getText() !== 'route'
-      )
-        continue;
-      const args = element.getArguments();
+  modifyReactRouterRoutes(file, (arr) => {
+    filterElements(file, arr, (element) => {
+      if (element.type !== 'CallExpression') return true;
+      const { callee, arguments: args } = element;
+      if (callee.type !== 'Identifier' || callee.name !== 'route') return true;
 
-      if (
-        filter({
-          path: getCodeValue(args[0].getText()),
-          entry: getCodeValue(args[1].getText()),
-        })
-      )
-        continue;
-
-      arr.removeElement(element);
-    }
+      return filter({
+        path: getCodeValue(file.code.slice(args[0].start, args[0].end)),
+        entry: getCodeValue(file.code.slice(args[1].start, args[1].end)),
+      });
+    });
   });
 }
 
-export function modifyReactRouterRoutes(
-  sourceFile: SourceFile,
-  mod: (array: ArrayLiteralExpression) => void,
-) {
-  const initializer = sourceFile
-    .getDefaultExportSymbol()
-    ?.getValueDeclaration()
-    ?.getFirstDescendantByKind(SyntaxKind.ArrayLiteralExpression);
+export function modifyReactRouterRoutes(file: SourceFile, mod: (array: ArrayExpression) => void) {
+  const initializer = getDefaultExport(file) && find(getDefaultExport(file)!, 'ArrayExpression');
   if (initializer) mod(initializer);
+}
+
+function getDefaultExport(file: SourceFile) {
+  return file.program.body.find((node) => node.type === 'ExportDefaultDeclaration');
 }
 
 /**
  * Find the prerender method from the config
  */
-function getPrerenderMethod(sourceFile: SourceFile): MethodDeclaration | null {
-  return (
-    sourceFile
-      .getDefaultExportSymbol()
-      ?.getValueDeclaration()
-      ?.getFirstDescendantByKind(SyntaxKind.ObjectLiteralExpression)
-      ?.getProperty('prerender')
-      ?.asKind(SyntaxKind.MethodDeclaration) ?? null
-  );
+function getPrerenderMethod(file: SourceFile): ObjectProperty | undefined {
+  const exported = getDefaultExport(file);
+  const options = exported && find(exported, 'ObjectExpression');
+  const property = options && getProperty(options, 'prerender');
+  if (property?.method) return property;
 }

--- a/packages/create-app/src/transform/shared.ts
+++ b/packages/create-app/src/transform/shared.ts
@@ -1,6 +1,7 @@
 import {
   parseSync,
   type ArrayExpression,
+  type ExportDefaultDeclaration,
   type JSXElement,
   type JSXOpeningElement,
   type Node,
@@ -58,22 +59,23 @@ export function* descendants(node: Node): Generator<Node> {
   }
 }
 
-export function find<T extends Node['type']>(node: Node, type: T): NodeOfType<T> | undefined {
+export function find<T extends Node['type']>(
+  node: Node,
+  type: T,
+  predicate?: (node: NodeOfType<T>) => boolean,
+): NodeOfType<T> | undefined {
   for (const child of descendants(node)) {
-    if (child.type === type) return child as NodeOfType<T>;
+    if (child.type === type && (!predicate || predicate(child as NodeOfType<T>)))
+      return child as NodeOfType<T>;
   }
 }
 
-export function findAll<T extends Node['type']>(node: Node, type: T): NodeOfType<T>[] {
-  const out: NodeOfType<T>[] = [];
-  for (const child of descendants(node)) {
-    if (child.type === type) out.push(child as NodeOfType<T>);
-  }
-  return out;
+export function getDefaultExport(file: SourceFile): ExportDefaultDeclaration | undefined {
+  return file.program.body.find((node) => node.type === 'ExportDefaultDeclaration');
 }
 
 export function findJsxElement(file: SourceFile, tagName: string): JSXElement | undefined {
-  return findAll(file.program, 'JSXElement').find(({ openingElement: { name } }) => {
+  return find(file.program, 'JSXElement', ({ openingElement: { name } }) => {
     return name.type === 'JSXIdentifier' && name.name === tagName;
   });
 }
@@ -193,19 +195,25 @@ export function filterElements<C extends Container>(
 ) {
   const { s } = file;
   const elements = getElements(container);
-  const kept = elements.filter(keep);
-  if (kept.length === elements.length) return;
-  if (kept.length === 0) {
+  const keeps = elements.map(keep);
+  let kept = 0;
+  for (const keep of keeps) if (keep) kept++;
+  if (kept === elements.length) return;
+  if (kept === 0) {
     s.remove(container.start + 1, container.end - 1);
     return;
   }
 
+  let lastKept: ElementOf<C> | undefined;
   for (let i = 0; i < elements.length; i++) {
     const element = elements[i];
-    if (kept.includes(element)) continue;
+    if (keeps[i]) {
+      lastKept = element;
+      continue;
+    }
     const next = elements[i + 1];
     // remove along with the separator: up to the next item, or from the last kept item
     if (next) s.remove(element.start, next.start);
-    else s.remove(kept.at(-1)!.end, element.end);
+    else s.remove(lastKept!.end, element.end);
   }
 }

--- a/packages/create-app/src/transform/shared.ts
+++ b/packages/create-app/src/transform/shared.ts
@@ -1,21 +1,211 @@
-import { IndentationText, Project, QuoteKind } from 'ts-morph';
+import {
+  parseSync,
+  type ArrayExpression,
+  type JSXElement,
+  type JSXOpeningElement,
+  type Node,
+  type ObjectExpression,
+  type ObjectProperty,
+  type Program,
+} from 'oxc-parser';
+import MagicString from 'magic-string';
 import fs from 'node:fs/promises';
 
-const project = new Project({
-  skipAddingFilesFromTsConfig: true,
-  skipLoadingLibFiles: true,
-  manipulationSettings: {
-    indentationText: IndentationText.TwoSpaces,
-    quoteKind: QuoteKind.Single,
-  },
-});
+export type NodeOfType<T extends Node['type']> = Extract<Node, { type: T }>;
 
-export async function createSourceFile(path: string) {
-  return project.createSourceFile(path, await fs.readFile(path, 'utf-8'), {
-    overwrite: true,
-  });
+export interface SourceFile {
+  path: string;
+  /** the original content */
+  code: string;
+  program: Program;
+  /** the edited content */
+  s: MagicString;
+  save(): Promise<void>;
+}
+
+export function parseSourceFile(path: string, code: string): SourceFile {
+  const { program, errors } = parseSync(path, code);
+  if (errors.length > 0) throw new Error(`Failed to parse ${path}: ${errors[0].message}`);
+  const s = new MagicString(code);
+
+  return {
+    path,
+    code,
+    program,
+    s,
+    save: () => fs.writeFile(path, s.toString()),
+  };
+}
+
+export async function createSourceFile(path: string): Promise<SourceFile> {
+  return parseSourceFile(path, await fs.readFile(path, 'utf-8'));
 }
 
 export function getCodeValue(v: string) {
   return new Function(`return ${v}`)();
+}
+
+export function* descendants(node: Node): Generator<Node> {
+  for (const key in node) {
+    if (key === 'parent') continue;
+    const value = (node as unknown as Record<string, unknown>)[key];
+    for (const child of Array.isArray(value) ? value : [value]) {
+      if (child && typeof child === 'object' && 'type' in child) {
+        yield child as Node;
+        yield* descendants(child as Node);
+      }
+    }
+  }
+}
+
+export function find<T extends Node['type']>(node: Node, type: T): NodeOfType<T> | undefined {
+  for (const child of descendants(node)) {
+    if (child.type === type) return child as NodeOfType<T>;
+  }
+}
+
+export function findAll<T extends Node['type']>(node: Node, type: T): NodeOfType<T>[] {
+  const out: NodeOfType<T>[] = [];
+  for (const child of descendants(node)) {
+    if (child.type === type) out.push(child as NodeOfType<T>);
+  }
+  return out;
+}
+
+export function findJsxElement(file: SourceFile, tagName: string): JSXElement | undefined {
+  return findAll(file.program, 'JSXElement').find(({ openingElement: { name } }) => {
+    return name.type === 'JSXIdentifier' && name.name === tagName;
+  });
+}
+
+export function addJsxAttribute(file: SourceFile, element: JSXOpeningElement, attribute: string) {
+  const { code, s } = file;
+  const anchor = element.attributes.at(-1) ?? element.name;
+  const multiline = code.slice(element.start, element.end).includes('\n');
+  s.appendLeft(
+    anchor.end,
+    `${multiline ? `\n${lineIndent(code, anchor.start)}` : ' '}${attribute}`,
+  );
+}
+
+/**
+ * Insert JSX before the children of the element, re-indenting the children
+ */
+export function prependJsxChildren(file: SourceFile, element: JSXElement, jsx: string) {
+  const { closingElement, openingElement } = element;
+  if (!closingElement) return;
+  const { code, s } = file;
+  const indent = lineIndent(code, element.start);
+  const prior = dedent(code.slice(openingElement.end, closingElement.start));
+  const body = `${jsx}\n\n${prior}`.replaceAll(/^(?=.)/gm, `${indent}  `);
+  s.overwrite(openingElement.end, closingElement.start, `\n${body}\n${indent}`);
+}
+
+/** trim, and remove the common indentation */
+function dedent(text: string): string {
+  const lines = text.trim().split('\n');
+  let indent: string | undefined;
+  for (const line of lines.slice(1)) {
+    if (line.trim().length === 0) continue;
+    const current = /^[ \t]*/.exec(line)![0];
+    if (indent === undefined || current.length < indent.length) indent = current;
+  }
+  if (!indent) return lines.join('\n');
+  return lines
+    .map((line, i) => (i > 0 && line.startsWith(indent) ? line.slice(indent.length) : line))
+    .join('\n');
+}
+
+export function getProperty(object: ObjectExpression, name: string): ObjectProperty | undefined {
+  for (const property of object.properties) {
+    if (property.type !== 'Property') continue;
+    const { key } = property;
+    if (
+      key.type === 'Identifier' ? key.name === name : key.type === 'Literal' && key.value === name
+    )
+      return property;
+  }
+}
+
+/** indentation of the line containing `index` */
+export function lineIndent(code: string, index: number): string {
+  const start = code.lastIndexOf('\n', index - 1) + 1;
+  return /^[ \t]*/.exec(code.slice(start, index))![0];
+}
+
+export function addImport(
+  file: SourceFile,
+  declaration: { from: string; default?: string; named?: string[] },
+) {
+  const parts: string[] = [];
+  if (declaration.default) parts.push(declaration.default);
+  if (declaration.named?.length) parts.push(`{ ${declaration.named.join(', ')} }`);
+  const statement = `import ${parts.join(', ')} from '${declaration.from}';`;
+
+  const last = file.program.body.findLast((node) => node.type === 'ImportDeclaration');
+  if (last) file.s.appendLeft(last.end, `\n${statement}`);
+  else file.s.prepend(`${statement}\n`);
+}
+
+type Container = ArrayExpression | ObjectExpression;
+type ElementOf<C extends Container> = C extends ArrayExpression
+  ? NonNullable<ArrayExpression['elements'][number]>
+  : ObjectExpression['properties'][number];
+
+function getElements<C extends Container>(container: C): ElementOf<C>[] {
+  const elements = container.type === 'ArrayExpression' ? container.elements : container.properties;
+  return elements.filter((element) => element !== null) as ElementOf<C>[];
+}
+
+/**
+ * Append items to an array or object literal, following its formatting
+ */
+export function addElements(file: SourceFile, container: Container, items: string[]) {
+  if (items.length === 0) return;
+  const { code, s } = file;
+  const last = getElements(container).at(-1);
+  const multiline = code.slice(container.start, container.end).includes('\n');
+
+  if (!last) {
+    s.overwrite(container.start + 1, container.end - 1, items.join(', '));
+    return;
+  }
+
+  if (!multiline) {
+    s.appendLeft(last.end, items.map((item) => `, ${item}`).join(''));
+    return;
+  }
+
+  const indent = lineIndent(code, last.start);
+  s.appendLeft(
+    last.end,
+    items.map((item) => `,\n${indent}${item.replaceAll('\n', `\n${indent}`)}`).join(''),
+  );
+}
+
+/**
+ * Remove the items of an array or object literal that don't pass the filter
+ */
+export function filterElements<C extends Container>(
+  file: SourceFile,
+  container: C,
+  keep: (element: ElementOf<C>) => boolean,
+) {
+  const { s } = file;
+  const elements = getElements(container);
+  const kept = elements.filter(keep);
+  if (kept.length === elements.length) return;
+  if (kept.length === 0) {
+    s.remove(container.start + 1, container.end - 1);
+    return;
+  }
+
+  for (let i = 0; i < elements.length; i++) {
+    const element = elements[i];
+    if (kept.includes(element)) continue;
+    const next = elements[i + 1];
+    // remove along with the separator: up to the next item, or from the last kept item
+    if (next) s.remove(element.start, next.start);
+    else s.remove(kept.at(-1)!.end, element.end);
+  }
 }

--- a/packages/create-app/src/transform/tanstack-start.ts
+++ b/packages/create-app/src/transform/tanstack-start.ts
@@ -1,5 +1,12 @@
 import type { CallExpression } from 'oxc-parser';
-import { addElements, find, getCodeValue, getProperty, type SourceFile } from '@/transform/shared';
+import {
+  addElements,
+  find,
+  getCodeValue,
+  getDefaultExport,
+  getProperty,
+  type SourceFile,
+} from '@/transform/shared';
 
 /**
  * Add path to the `pages` array in tanstack start vite config.
@@ -32,7 +39,7 @@ export function addTanstackPrerender(file: SourceFile, paths: string[]) {
  * Find the tanstackStart call expression
  */
 function getTanstackStartCall(file: SourceFile): CallExpression | undefined {
-  const exported = file.program.body.find((node) => node.type === 'ExportDefaultDeclaration');
+  const exported = getDefaultExport(file);
   const options = exported && find(exported, 'ObjectExpression');
   const plugins = options && getProperty(options, 'plugins')?.value;
   if (plugins?.type !== 'ArrayExpression') return;

--- a/packages/create-app/src/transform/tanstack-start.ts
+++ b/packages/create-app/src/transform/tanstack-start.ts
@@ -1,70 +1,48 @@
-import { CallExpression, SourceFile, SyntaxKind } from 'ts-morph';
-import { getCodeValue } from '@/transform/shared';
+import type { CallExpression } from 'oxc-parser';
+import { addElements, find, getCodeValue, getProperty, type SourceFile } from '@/transform/shared';
 
 /**
  * Add path to the `pages` array in tanstack start vite config.
  *
  * If the `pages` property doesn't exist, create one.
  */
-export function addTanstackPrerender(sourceFile: SourceFile, paths: string[]) {
-  const optionsArg = getTanstackStartCall(sourceFile)
-    ?.getArguments()[0]
-    ?.asKind(SyntaxKind.ObjectLiteralExpression);
-  if (!optionsArg) {
+export function addTanstackPrerender(file: SourceFile, paths: string[]) {
+  const options = getTanstackStartCall(file)?.arguments[0];
+  if (options?.type !== 'ObjectExpression') return;
+
+  const toItem = (path: string) => `{ path: '${path}' }`;
+  const pages = getProperty(options, 'pages')?.value;
+  if (!pages) {
+    addElements(file, options, [
+      `pages: [\n${paths.map((path) => `  ${toItem(path)}`).join(',\n')}\n]`,
+    ]);
     return;
   }
+  if (pages.type !== 'ArrayExpression') return;
 
-  const pagesProperty = optionsArg.getProperty('pages')?.asKind(SyntaxKind.PropertyAssignment);
-
-  function toItem(path: string) {
-    return `{ path: '${path}' }`;
+  const existingPaths = new Set<string>();
+  for (const element of pages.elements) {
+    const value = element?.type === 'ObjectExpression' && getProperty(element, 'path')?.value;
+    if (value) existingPaths.add(getCodeValue(file.code.slice(value.start, value.end)));
   }
-
-  if (pagesProperty) {
-    const initializer = pagesProperty.getInitializerIfKindOrThrow(
-      SyntaxKind.ArrayLiteralExpression,
-    );
-
-    const existingPaths = new Set<string>();
-    for (const element of initializer.getElements()) {
-      const value = element
-        .asKind(SyntaxKind.ObjectLiteralExpression)
-        ?.getProperty('path')
-        ?.asKind(SyntaxKind.PropertyAssignment)
-        ?.getInitializer()
-        ?.getText();
-
-      if (value) {
-        existingPaths.add(getCodeValue(value));
-      }
-    }
-
-    for (const path of paths) {
-      if (existingPaths.has(path)) continue;
-      initializer.addElement(toItem(path));
-    }
-  } else {
-    optionsArg.addProperty(`pages: [\n${paths.map((path) => `  ${toItem(path)}`).join(',\n')}\n]`);
-  }
+  addElements(file, pages, paths.filter((path) => !existingPaths.has(path)).map(toItem));
 }
 
 /**
  * Find the tanstackStart call expression
  */
-function getTanstackStartCall(sourceFile: SourceFile): CallExpression | undefined {
-  const pluginsProperty = sourceFile
-    .getDefaultExportSymbol()
-    ?.getValueDeclaration()
-    ?.getFirstDescendantByKind(SyntaxKind.ObjectLiteralExpression)
-    ?.getProperty('plugins')
-    ?.getFirstChildByKind(SyntaxKind.ArrayLiteralExpression);
+function getTanstackStartCall(file: SourceFile): CallExpression | undefined {
+  const exported = file.program.body.find((node) => node.type === 'ExportDefaultDeclaration');
+  const options = exported && find(exported, 'ObjectExpression');
+  const plugins = options && getProperty(options, 'plugins')?.value;
+  if (plugins?.type !== 'ArrayExpression') return;
 
-  if (!pluginsProperty) return;
-
-  for (const element of pluginsProperty.getElements()) {
-    const expression = element.asKind(SyntaxKind.CallExpression);
-    if (expression?.getFirstChildByKind(SyntaxKind.Identifier)?.getText() === 'tanstackStart') {
-      return expression;
-    }
+  for (const element of plugins.elements) {
+    if (
+      element?.type === 'CallExpression' &&
+      element.callee.type === 'Identifier' &&
+      element.callee.name === 'tanstackStart'
+    )
+      return element;
   }
 }

--- a/packages/create-app/test/fixtures/react-router-routes(add-routes).output.txt
+++ b/packages/create-app/test/fixtures/react-router-routes(add-routes).output.txt
@@ -5,5 +5,5 @@ export default [
   route('docs/*', 'docs/page.tsx'),
   route('api/search', 'docs/search.ts'),
   route('api/og/*', './api/og.tsx'),
-  route('/static.json', './static.ts')
+  route('/static.json', './static.ts'),
 ] satisfies RouteConfig;

--- a/packages/create-app/test/fixtures/react-router-routes(filter-routes).output.txt
+++ b/packages/create-app/test/fixtures/react-router-routes(filter-routes).output.txt
@@ -2,5 +2,5 @@ import { index, route, type RouteConfig } from '@react-router/dev/routes';
 
 export default [
   index('routes/home.tsx'),
-  route('docs/*', 'docs/page.tsx')
+  route('docs/*', 'docs/page.tsx'),
 ] satisfies RouteConfig;

--- a/packages/create-app/test/fixtures/tanstack-vite-config(add-pages).output.txt
+++ b/packages/create-app/test/fixtures/tanstack-vite-config(add-pages).output.txt
@@ -22,7 +22,7 @@ export default defineConfig({
       pages: [
         { path: '/static.json' },
         { path: '/docs/test' }
-      ]
+      ],
     }),
     react(),
   ],

--- a/packages/create-app/test/index.test.ts
+++ b/packages/create-app/test/index.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from 'vitest';
-import { IndentationText, Project, QuoteKind } from 'ts-morph';
 import { addTanstackPrerender } from '@/transform/tanstack-start';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -8,29 +7,42 @@ import {
   filterReactRouterPrerenderArray,
   filterReactRouterRoute,
 } from '@/transform/react-router';
-
-const project = new Project({
-  useInMemoryFileSystem: true,
-  manipulationSettings: {
-    indentationText: IndentationText.TwoSpaces,
-    quoteKind: QuoteKind.Single,
-  },
-});
+import {
+  addImport,
+  addJsxAttribute,
+  findJsxElement,
+  parseSourceFile,
+  prependJsxChildren,
+} from '@/transform/shared';
 
 async function createSourceFile(templatePath: string) {
   const content = await fs.readFile(path.join(__dirname, templatePath), 'utf-8');
-
-  return project.createSourceFile('temp.ts', content, {
-    overwrite: true,
-  });
+  return parseSourceFile('temp.ts', content);
 }
 
 test('transform tanstack start vite config: add pages', async () => {
   const sourceFile = await createSourceFile('fixtures/tanstack-vite-config.txt');
   addTanstackPrerender(sourceFile, ['/static.json', '/docs/test']);
-  await expect(sourceFile.getFullText()).toMatchFileSnapshot(
+  await expect(sourceFile.s.toString()).toMatchFileSnapshot(
     'fixtures/tanstack-vite-config(add-pages).output.txt',
   );
+});
+
+test('transform tanstack start vite config: extend pages', async () => {
+  const sourceFile = parseSourceFile(
+    'temp.ts',
+    `export default defineConfig({
+  plugins: [tanstackStart({ pages: [{ path: '/a' }] })],
+});
+`,
+  );
+  addTanstackPrerender(sourceFile, ['/a', '/b']);
+  expect(sourceFile.s.toString()).toMatchInlineSnapshot(`
+    "export default defineConfig({
+      plugins: [tanstackStart({ pages: [{ path: '/a' }, { path: '/b' }] })],
+    });
+    "
+  `);
 });
 
 test('transform react router routes: add routes', async () => {
@@ -45,7 +57,7 @@ test('transform react router routes: add routes', async () => {
       entry: './static.ts',
     },
   ]);
-  await expect(sourceFile.getFullText()).toMatchFileSnapshot(
+  await expect(sourceFile.s.toString()).toMatchFileSnapshot(
     'fixtures/react-router-routes(add-routes).output.txt',
   );
 });
@@ -53,7 +65,7 @@ test('transform react router routes: add routes', async () => {
 test('transform react router routes: filter routes', async () => {
   const sourceFile = await createSourceFile('fixtures/react-router-routes.txt');
   filterReactRouterRoute(sourceFile, ({ path }) => path !== 'api/search');
-  await expect(sourceFile.getFullText()).toMatchFileSnapshot(
+  await expect(sourceFile.s.toString()).toMatchFileSnapshot(
     'fixtures/react-router-routes(filter-routes).output.txt',
   );
 });
@@ -61,7 +73,75 @@ test('transform react router routes: filter routes', async () => {
 test('transform react router config: remove exclude', async () => {
   const sourceFile = await createSourceFile('fixtures/react-router-config.txt');
   filterReactRouterPrerenderArray(sourceFile, 'excluded', (v) => v !== '/api/search');
-  await expect(sourceFile.getFullText()).toMatchFileSnapshot(
+  await expect(sourceFile.s.toString()).toMatchFileSnapshot(
     'fixtures/react-router-config(remove-exclude).output.txt',
   );
+});
+
+test('transform jsx', () => {
+  const sourceFile = parseSourceFile(
+    'layout.tsx',
+    `import { RootProvider } from 'fumadocs-ui/provider';
+
+export default function Layout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <RootProvider theme={{ enabled: false }}>
+        <DocsLayout
+          tree={source.pageTree}
+          nav={{ title: 'Docs' }}
+        >
+          {children}
+          <Footer />
+        </DocsLayout>
+      </RootProvider>
+    </html>
+  );
+}
+`,
+  );
+  addJsxAttribute(
+    sourceFile,
+    findJsxElement(sourceFile, 'RootProvider')!.openingElement,
+    'search={{ SearchDialog }}',
+  );
+  addJsxAttribute(
+    sourceFile,
+    findJsxElement(sourceFile, 'DocsLayout')!.openingElement,
+    'sidebar={{ collapsible: false }}',
+  );
+  prependJsxChildren(
+    sourceFile,
+    findJsxElement(sourceFile, 'DocsLayout')!,
+    '<AISearch>\n  <AISearchTrigger />\n</AISearch>',
+  );
+  addImport(sourceFile, { from: '@/components/search', default: 'SearchDialog' });
+  addImport(sourceFile, { from: '@/components/ai', named: ['AISearch', 'AISearchTrigger'] });
+  expect(sourceFile.s.toString()).toMatchInlineSnapshot(`
+    "import { RootProvider } from 'fumadocs-ui/provider';
+    import SearchDialog from '@/components/search';
+    import { AISearch, AISearchTrigger } from '@/components/ai';
+
+    export default function Layout({ children }: LayoutProps<'/'>) {
+      return (
+        <html>
+          <RootProvider theme={{ enabled: false }} search={{ SearchDialog }}>
+            <DocsLayout
+              tree={source.pageTree}
+              nav={{ title: 'Docs' }}
+              sidebar={{ collapsible: false }}
+            >
+              <AISearch>
+                <AISearchTrigger />
+              </AISearch>
+
+              {children}
+              <Footer />
+            </DocsLayout>
+          </RootProvider>
+        </html>
+      );
+    }
+    "
+  `);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2482,15 +2482,18 @@ importers:
       fuma-cli:
         specifier: ^0.1.1
         version: 0.1.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      magic-string:
+        specifier: ^1.2.3
+        version: 1.2.3
+      oxc-parser:
+        specifier: ^0.128.0
+        version: 0.128.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
       tinyexec:
         specifier: ^1.3.0
         version: 1.3.0
-      ts-morph:
-        specifier: ^28.0.0
-        version: 28.0.0
     devDependencies:
       '@types/cross-spawn':
         specifier: ^6.0.6
@@ -9215,9 +9218,6 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
-  '@ts-morph/common@0.29.0':
-    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
-
   '@tsdown/css@0.22.14':
     resolution: {integrity: sha512-0NpbgqfhfjaAoLdY3DxjrMo08vKFEtvlybCS42Gtolx8OPoKUdZZDyls0qgNEqea0c7XGjlF0NIE1tIxgU8RqA==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -15231,9 +15231,6 @@ packages:
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
-
-  ts-morph@28.0.0:
-    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
@@ -22042,12 +22039,6 @@ snapshots:
       fast-glob: 3.3.3
       minimatch: 10.2.6
       path-browserify: 1.0.1
-
-  '@ts-morph/common@0.29.0':
-    dependencies:
-      minimatch: 10.2.6
-      path-browserify: 1.0.1
-      tinyglobby: 0.2.17
 
   '@tsdown/css@0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.13)(yaml@2.9.0)':
     dependencies:
@@ -28992,11 +28983,6 @@ snapshots:
   ts-morph@26.0.0:
     dependencies:
       '@ts-morph/common': 0.27.0
-      code-block-writer: 13.0.3
-
-  ts-morph@28.0.0:
-    dependencies:
-      '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
   tsconfig-paths@4.2.0:


### PR DESCRIPTION
## Summary

Template transforms in `create-fumadocs-app` (routes, prerender config, `RootProvider` search dialog, AI chat layout) now parse files with `oxc-parser` and edit the source text in place with `magic-string`, instead of `ts-morph` and the TypeScript 6 compiler it bundles. This removes the last use of TypeScript 6 in the repo.

Edits preserve the original formatting, including trailing commas. The stackblitz example is bumped to TypeScript 7 as well.

## Related Issues

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/fuma-nama/fumadocs/blob/dev/.github/contributing.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

## Additional Context

Changeset: `create-fumadocs-app` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdE5FdRFSfFHzSApgnQoFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdE5FdRFSfFHzSApgnQoFo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the app creation process to preserve existing source formatting, including trailing commas, when configuring routes, prerendering, search, and AI chat features.
  - Improved transformations for React Router and TanStack Start projects, including adding pages and routes without duplicating existing entries.
  - Enhanced JSX-based template updates for search dialogs and AI layouts.
- **Bug Fixes**
  - Corrected generated configuration output to maintain consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->